### PR TITLE
Add Deluge Label plugin support with dynamic tool visibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,9 @@
 
 ## Project Overview
 
-An MCP server written in Rust that bridges AI assistants to a running Deluge torrent daemon (`deluged`). Built with the [Model Context Protocol Rust SDK](https://github.com/modelcontextprotocol/rust-sdk), it exposes 13 tools covering torrent management (add, remove, list, pause, resume, status), file operations (move storage, rename folders/files, force recheck), and server queries (free space, path size).
+An MCP server written in Rust that bridges AI assistants to a running Deluge torrent daemon (`deluged`). Built with the [Model Context Protocol Rust SDK](https://github.com/modelcontextprotocol/rust-sdk), it exposes 21 tools covering torrent management (add, remove, list, pause, resume, status), file operations (move storage, rename folders/files, force recheck), Label-plugin operations (list/create/delete labels, get/set per-label options, assign labels to torrents, pause/resume by label), and server queries (free space, path size).
 
-Supports both **stdio** (Claude Desktop) and **HTTP/SSE** (remote/agentic) transports. Includes tiered safety gates to guard against LLM hallucination, and configurable TLS certificate handling for Deluge's default self-signed certificates.
+Supports both **stdio** (Claude Desktop) and **HTTP/SSE** (remote/agentic) transports. Includes tiered safety gates to guard against LLM hallucination, and configurable TLS certificate handling for Deluge's default self-signed certificates. Tools that depend on Deluge plugins (currently the Label plugin) are dynamically shown or hidden based on whether the plugin is enabled on the daemon — toggling the plugin in any Deluge client is reflected in the MCP `tools/list` within seconds via Deluge's `PluginEnabledEvent` / `PluginDisabledEvent` push events.
 
 ## Tech Stack
 Rust for the code
@@ -66,24 +66,50 @@ Deluge exposes a custom binary RPC protocol over TCP (default port 58846). The d
 | `force_recheck` | `core.force_recheck` | Force a hash recheck of one or more torrents' files |
 | `get_free_space` | `core.get_free_space` | Get free disk space for a given path |
 | `get_path_size` | `core.get_path_size` | Get the size of a path on the server |
+| `list_labels` | `label.get_labels` | List all labels defined on the daemon (requires Label plugin) |
+| `create_label` | `label.add` | Create a new label on the daemon (requires Label plugin) |
+| `delete_label` | `label.remove` | Delete a label; assigned torrents become unlabeled (requires Label plugin) |
+| `set_torrent_label` | `label.set_torrent` | Assign a label to one or more torrents — empty string or `"No Label"` clears (requires Label plugin) |
+| `pause_label` | `core.get_torrents_status` + `core.pause_torrents` | Pause every torrent assigned the given label (requires Label plugin) |
+| `resume_label` | `core.get_torrents_status` + `core.resume_torrents` | Resume every torrent assigned the given label (requires Label plugin) |
+| `get_label_options` | `label.get_options` | Get a label's default options (speed caps, ratio handling, etc.) (requires Label plugin) |
+| `set_label_options` | `label.set_options` | Set a label's default options; applied to every torrent carrying the label (requires Label plugin) |
+
+`list_torrents` also accepts a `label` filter and, when the Label plugin is active, includes each torrent's `label` in the returned status fields.
 
 Torrents are identified by their **info hash** (40-character hex string / SHA-1).
 
 ### Safety Gates
 
-Tools have two default states. Five tools are **disabled by default** to guard against LLM hallucination:
+Tools have two default states. Eight tools are **disabled by default** to guard against LLM hallucination:
 
 | Tool | Default | Reason |
 |---|---|---|
 | `add_torrent`, `list_torrents`, `get_torrent_status`, `pause_torrent`, `resume_torrent`, `set_torrent_options`, `get_free_space`, `get_path_size` | enabled | Safe read/write operations |
+| `list_labels`, `get_label_options`, `set_torrent_label`, `pause_label`, `resume_label` | enabled (when Label plugin is active) | Read labels or apply/act on existing labels — non-destructive |
 | `move_storage`, `rename_folder`, `rename_files`, `force_recheck` | disabled | Modifies filesystem paths or interrupts downloads |
+| `create_label`, `delete_label`, `set_label_options` | disabled | Mutates label state — must require explicit operator opt-in |
 | `remove_torrent` | disabled | Can permanently delete downloaded data |
 
 Tools are enabled or disabled via `--enable-tool <PATTERN>` / `--disable-tool <PATTERN>`. Patterns are matched as case-sensitive substrings of tool names (minimum 3 characters). Both singular (`--enable-tool`) and plural (`--enable-tools`) forms are accepted. Flags are processed in CLI order — later flags override earlier ones.
 
-`--list-tools` prints all tools with their default state and exits without requiring credentials.
+`--list-tools` prints all tools with their current visibility, default state, and any plugin gating, and exits without requiring credentials.
 
-When a disabled tool is called, the server returns an error to the LLM with the exact `--enable-tool` flag needed to enable it.
+When a disabled tool is called, the server returns an error to the LLM. The hint distinguishes between CLI-disabled tools (suggests `--enable-tool=<name>`) and plugin-gated tools (suggests enabling the plugin in Deluge).
+
+### Label Plugin Gating
+
+Eight tools (`list_labels`, `create_label`, `delete_label`, `set_torrent_label`, `pause_label`, `resume_label`, `get_label_options`, `set_label_options`) require Deluge's built-in **Label** plugin to be enabled on the daemon. Visibility rule:
+
+> A label tool is visible to MCP clients **iff** (it is enabled — by default or by `--enable-tool`) **AND** (the Label plugin is currently active on the daemon).
+
+Plugin gating is absolute — `--enable-tool` cannot make a label tool visible if the plugin is inactive. The MCP server detects plugin state via:
+
+1. A one-time probe of `core.get_enabled_plugins` after authentication.
+2. Subscription to the daemon's `PluginEnabledEvent` and `PluginDisabledEvent` push events (the same mechanism Deluge's GTK and Web UIs use). Toggling the plugin from any Deluge client — GTK preferences, Web UI, `deluge-console plugin --enable Label` — propagates to the MCP server within seconds.
+3. Re-probing on reconnect and on broadcast lag (belt-and-suspenders against missed events).
+
+When the plugin state flips, the MCP server fires `notifications/tools/list_changed` to every connected MCP peer so conforming clients refresh their tool list.
 
 ### Wire Format
 
@@ -123,7 +149,7 @@ Implemented via `native-tls` with `danger_accept_invalid_certs(true)`. After the
 | `src/main.rs` | Entry point — CLI arg parsing, transport selection, server startup, HTTP auth middleware. |
 | `src/rencode.rs` | Internal rencode serializer/deserializer (Deluge wire format). |
 | `src/deluge/mod.rs` | Deluge RPC client — TLS connection, cert fingerprint logging/pinning, auth, request multiplexing, zlib framing. |
-| `src/tools/mod.rs` | MCP tool implementations — all 13 tools, safety gate helpers, Value→JSON conversion. |
+| `src/tools/mod.rs` | MCP tool implementations — all 21 tools, safety gate helpers, plugin watcher, Value→JSON conversion. |
 | `tests/` | Integration tests. |
 
 ## Commands

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "deluge-torrent-mcp"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deluge-torrent-mcp"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 license = "MIT"
 authors = ["Sandy McArthur, Jr."]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ By integrating this server, your AI assistant can seamlessly manage your torrent
 
 - **Native RPC Integration**: Uses Deluge's native binary protocol (rencode/zlib over TLS) rather than relying on the WebUI API.
 - **Granular Safety Gates**: Prevents LLM hallucinations from accidentally deleting or moving your files. Risky tools are disabled by default and enabled individually via `--enable-tool`.
+- **Dynamic Label Plugin Support**: Exposes tools for Deluge's built-in Label plugin — create, delete, and list labels; assign labels to torrents; pause/resume by label; read and write per-label option defaults. Tools appear and disappear automatically as the plugin is enabled or disabled on the daemon, with no MCP server restart needed.
 - **Flexible TLS Handling**: Seamlessly handles Deluge's default self-signed certificates with a secure, copy-paste pinning mechanism.
 - **Dual Transports**: Supports stdio (for local Claude Desktop use) and HTTP/SSE (for remote agentic frameworks).
 
@@ -79,7 +80,7 @@ deluge-torrent-mcp --host 192.168.1.50 --port 58846 -u admin -p secret [OPTIONS]
 
 ## Safety Gates
 
-By default, the server runs in **Safe Mode** — the AI can list, add, pause, and resume torrents, but cannot alter the filesystem or remove torrents. Five tools are disabled by default:
+By default, the server runs in **Safe Mode** — the AI can list, add, pause, and resume torrents, but cannot alter the filesystem, remove torrents, or mutate the label set. Eight tools are disabled by default:
 
 | Tool | Reason |
 |---|---|
@@ -88,6 +89,9 @@ By default, the server runs in **Safe Mode** — the AI can list, add, pause, an
 | `rename_files` | Modifies filesystem paths |
 | `force_recheck` | Interrupts active downloads |
 | `remove_torrent` | Can permanently delete downloaded data |
+| `create_label` | Mutates label set on the daemon |
+| `delete_label` | Removes labels (destructive) |
+| `set_label_options` | Rewrites per-label default options (speed caps, move-completed path, etc.) |
 
 Use `--list-tools` to see the full list and current defaults:
 
@@ -112,6 +116,27 @@ deluge-torrent-mcp -u admin -p secret --enable-tools=move_storage,rename_folder,
 ```
 
 When a disabled tool is called, the server returns an error to the AI describing the exact flag needed to enable it.
+
+## Label Plugin
+
+Deluge ships a built-in **Label** plugin for grouping and bulk-operating on torrents. When the plugin is enabled on the daemon, the MCP server exposes eight label-aware tools:
+
+| Tool | Default |
+|---|---|
+| `list_labels` | enabled |
+| `get_label_options` | enabled |
+| `set_torrent_label` | enabled |
+| `pause_label` | enabled |
+| `resume_label` | enabled |
+| `create_label` | disabled — requires `--enable-tool=create_label` |
+| `delete_label` | disabled — requires `--enable-tool=delete_label` |
+| `set_label_options` | disabled — requires `--enable-tool=set_label_options` |
+
+`list_torrents` also accepts an optional `label` filter and, when the plugin is active, includes each torrent's `label` in the returned status fields.
+
+Because `--enable-tool` matches any substring of a tool name, a single `--enable-tool=label` enables every label tool at once (including the default-disabled `create_label`, `delete_label`, and `set_label_options`). Use more specific patterns — e.g. `--enable-tool=create_label` — to enable only one.
+
+**Dynamic visibility.** Label tools appear in `tools/list` only when the Label plugin is enabled on the daemon. The server subscribes to Deluge's `PluginEnabledEvent` / `PluginDisabledEvent` push events (the same mechanism the GTK and Web UIs use) — toggling the plugin in any Deluge client propagates to connected MCP peers within seconds via `notifications/tools/list_changed`. No MCP server restart is needed. `--enable-tool` cannot make a label tool visible if the plugin is inactive on the daemon.
 
 ## HTTP Transport
 

--- a/THIRD_PARTY_LICENSES.html
+++ b/THIRD_PARTY_LICENSES.html
@@ -4963,7 +4963,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/deluge-torrent-mcp ">deluge-torrent-mcp 0.6.1</a></li>
+                    <li><a href=" https://crates.io/crates/deluge-torrent-mcp ">deluge-torrent-mcp 0.7.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 

--- a/src/deluge/mod.rs
+++ b/src/deluge/mod.rs
@@ -35,7 +35,8 @@ const MAX_DECOMPRESSED_BYTES: usize = MAX_FRAME_BYTES * 4; // 128 MB decompresse
 
 type PendingMap = Mutex<HashMap<i64, oneshot::Sender<Result<Value>>>>;
 
-/// A push event received from the Deluge daemon via the RPC_EVENT wire message.
+/// A push event received from the Deluge daemon via the RPC_EVENT wire message,
+/// plus synthetic local events the client emits for connection lifecycle.
 #[derive(Debug, Clone)]
 pub enum DelugeEvent {
     TorrentAdded { info_hash: String, from_state: bool },
@@ -46,6 +47,11 @@ pub enum DelugeEvent {
     TorrentStorageMoved { info_hash: String, path: String },
     TorrentFileRenamed { info_hash: String, index: i64, name: String },
     TorrentFolderRenamed { info_hash: String, old_name: String, new_name: String },
+    PluginEnabled { name: String },
+    PluginDisabled { name: String },
+    /// Synthetic event fired locally after a (re)connect + event-interest registration.
+    /// Listeners that track server-side state (e.g. plugin enablement) should re-seed.
+    Reconnected,
     Unknown { name: String },
 }
 
@@ -252,6 +258,8 @@ impl DelugeClient {
                 Value::String("TorrentStorageMovedEvent".into()),
                 Value::String("TorrentFileRenamedEvent".into()),
                 Value::String("TorrentFolderRenamedEvent".into()),
+                Value::String("PluginEnabledEvent".into()),
+                Value::String("PluginDisabledEvent".into()),
             ])],
             vec![],
         )
@@ -261,6 +269,10 @@ impl DelugeClient {
         } else {
             debug!("Registered for Deluge push events");
         }
+
+        // Notify subscribers that we're (re)connected and re-subscribed.
+        // Has no effect on initial connect (no subscribers yet).
+        let _ = self.event_tx.send(DelugeEvent::Reconnected);
 
         Ok((LiveConn { generation, writer, pending }, auth_level))
     }
@@ -562,6 +574,8 @@ fn parse_event(name: &str, args: &[Value]) -> DelugeEvent {
             old_name: str_arg(1),
             new_name: str_arg(2),
         },
+        "PluginEnabledEvent" => DelugeEvent::PluginEnabled { name: str_arg(0) },
+        "PluginDisabledEvent" => DelugeEvent::PluginDisabled { name: str_arg(0) },
         _ => DelugeEvent::Unknown { name: name.to_string() },
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,14 @@ const ALL_TOOLS: &[&str] = &[
     "deluge_rename_files",
     "deluge_force_recheck",
     "deluge_remove_torrent",
+    "deluge_list_labels",
+    "deluge_create_label",
+    "deluge_delete_label",
+    "deluge_set_torrent_label",
+    "deluge_pause_label",
+    "deluge_resume_label",
+    "deluge_get_label_options",
+    "deluge_set_label_options",
 ];
 
 /// Tools that are disabled unless explicitly enabled via --enable.
@@ -39,6 +47,22 @@ const DEFAULT_DISABLED: &[&str] = &[
     "deluge_rename_files",
     "deluge_force_recheck",
     "deluge_remove_torrent",
+    "deluge_create_label",
+    "deluge_delete_label",
+    "deluge_set_label_options",
+];
+
+/// Tools that depend on the Deluge Label plugin being enabled on the daemon.
+/// Hidden from `tools/list` whenever the plugin is inactive, regardless of CLI flags.
+const PLUGIN_GATED_LABEL_TOOLS: &[&str] = &[
+    "deluge_list_labels",
+    "deluge_create_label",
+    "deluge_delete_label",
+    "deluge_set_torrent_label",
+    "deluge_pause_label",
+    "deluge_resume_label",
+    "deluge_get_label_options",
+    "deluge_set_label_options",
 ];
 
 #[derive(Parser, Debug)]
@@ -211,15 +235,21 @@ async fn main() -> anyhow::Result<()> {
 
     // Handle --list-tools before clap parsing so credentials aren't required.
     if std::env::args().any(|a| a == "--list-tools") {
-        eprintln!("{:<22} {:<10} {}", "TOOL", "STATUS", "DEFAULT");
-        eprintln!("{}", "-".repeat(46));
+        eprintln!("{:<28} {:<10} {:<10} {}", "TOOL", "STATUS", "DEFAULT", "PLUGIN");
+        eprintln!("{}", "-".repeat(64));
         for &tool in ALL_TOOLS {
             let status = if enabled_tools.contains(tool) { "visible" } else { "hidden" };
             let default = if DEFAULT_DISABLED.contains(&tool) { "disabled" } else { "enabled" };
-            eprintln!("{:<22} {:<10} {}", tool, status, default);
+            let plugin = if PLUGIN_GATED_LABEL_TOOLS.contains(&tool) { "Label" } else { "-" };
+            eprintln!("{:<28} {:<10} {:<10} {}", tool, status, default, plugin);
         }
         eprintln!();
         eprintln!("Visible tools are reported to the MCP client. Hidden tools are not.");
+        eprintln!(
+            "Tools in the PLUGIN column require that Deluge plugin to be enabled on the \
+             daemon — they are hidden from tools/list whenever the plugin is inactive, \
+             and reappear automatically when it is re-enabled."
+        );
         return Ok(());
     }
 
@@ -257,6 +287,22 @@ async fn main() -> anyhow::Result<()> {
     .await?;
     info!(auth_level, "Authenticated with Deluge daemon");
 
+    // Probe whether the Label plugin is currently active. The plugin watcher
+    // (spawned per DelugeServer below) keeps this value live thereafter.
+    let initial_label_plugin_active =
+        tools::probe_label_plugin(&client).await.unwrap_or(false);
+    if initial_label_plugin_active {
+        info!("Deluge Label plugin is enabled — label tools are available");
+    } else {
+        info!(
+            "Deluge Label plugin is not enabled — label tools are hidden until the user enables it"
+        );
+    }
+    let plugin_gated_tools: HashSet<String> = PLUGIN_GATED_LABEL_TOOLS
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
     if cli.test_connection {
         use crate::rencode::Value;
 
@@ -289,7 +335,13 @@ async fn main() -> anyhow::Result<()> {
     match cli.transport {
         Transport::Stdio => {
             info!("Starting MCP server on stdio");
-            let server = tools::DelugeServer::new(client, enabled_tools);
+            let server = tools::DelugeServer::new(
+                client,
+                enabled_tools,
+                plugin_gated_tools,
+                initial_label_plugin_active,
+            );
+            server.spawn_plugin_watcher();
             let service = server.serve(rmcp::transport::stdio()).await?;
             service.waiting().await?;
         }
@@ -316,12 +368,24 @@ async fn main() -> anyhow::Result<()> {
 
             info!(bind = %cli.http_bind, "Starting MCP server on HTTP");
 
-            // Build the MCP service — factory creates a DelugeServer per session
+            // Build the MCP service — factory creates a DelugeServer per session.
+            // Each session spawns its own plugin watcher so it gets independent
+            // tools/list_changed delivery to its own peer.
             let mcp_service = {
                 let client = client.clone();
                 let enabled_tools = enabled_tools.clone();
+                let plugin_gated_tools = plugin_gated_tools.clone();
                 StreamableHttpService::new(
-                    move || Ok(tools::DelugeServer::new(client.clone(), enabled_tools.clone())),
+                    move || {
+                        let server = tools::DelugeServer::new(
+                            client.clone(),
+                            enabled_tools.clone(),
+                            plugin_gated_tools.clone(),
+                            initial_label_plugin_active,
+                        );
+                        server.spawn_plugin_watcher();
+                        Ok(server)
+                    },
                     Arc::new(LocalSessionManager::default()),
                     StreamableHttpServerConfig::default(),
                 )

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,20 +235,24 @@ async fn main() -> anyhow::Result<()> {
 
     // Handle --list-tools before clap parsing so credentials aren't required.
     if std::env::args().any(|a| a == "--list-tools") {
-        eprintln!("{:<28} {:<10} {:<10} {}", "TOOL", "STATUS", "DEFAULT", "PLUGIN");
+        eprintln!("{:<28} {:<10} {:<10} {}", "TOOL", "CLI", "DEFAULT", "PLUGIN");
         eprintln!("{}", "-".repeat(64));
         for &tool in ALL_TOOLS {
-            let status = if enabled_tools.contains(tool) { "visible" } else { "hidden" };
+            let cli = if enabled_tools.contains(tool) { "enabled" } else { "disabled" };
             let default = if DEFAULT_DISABLED.contains(&tool) { "disabled" } else { "enabled" };
             let plugin = if PLUGIN_GATED_LABEL_TOOLS.contains(&tool) { "Label" } else { "-" };
-            eprintln!("{:<28} {:<10} {:<10} {}", tool, status, default, plugin);
+            eprintln!("{:<28} {:<10} {:<10} {}", tool, cli, default, plugin);
         }
         eprintln!();
-        eprintln!("Visible tools are reported to the MCP client. Hidden tools are not.");
         eprintln!(
-            "Tools in the PLUGIN column require that Deluge plugin to be enabled on the \
-             daemon — they are hidden from tools/list whenever the plugin is inactive, \
-             and reappear automatically when it is re-enabled."
+            "CLI 'enabled' tools pass the server-side safety gate. 'disabled' tools are \
+             rejected and excluded from tools/list."
+        );
+        eprintln!(
+            "Tools in the PLUGIN column additionally require that Deluge plugin to be \
+             enabled on the daemon — they are hidden from tools/list whenever the plugin \
+             is inactive (regardless of CLI state) and reappear automatically when it is \
+             re-enabled."
         );
         return Ok(());
     }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,8 +1,8 @@
 // Copyright (c) 2026 Sandy McArthur, Jr.
 // SPDX-License-Identifier: MIT
 
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, RwLock as StdRwLock};
 
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use rmcp::{
@@ -11,11 +11,12 @@ use rmcp::{
     handler::server::tool::ToolCallContext,
     handler::server::wrapper::Parameters,
     model::{
-        CallToolRequestParams, CallToolResult, Icon, Implementation, ListResourcesResult,
-        ListResourceTemplatesResult, ListToolsResult, PaginatedRequestParams, RawResource,
-        RawResourceTemplate, ReadResourceRequestParams, ReadResourceResult, Resource,
-        ResourceContents, ResourceTemplate, ResourceUpdatedNotificationParam, ServerInfo,
-        SetLevelRequestParams, SubscribeRequestParams, Tool, UnsubscribeRequestParams,
+        CallToolRequestParams, CallToolResult, Icon, Implementation, InitializeRequestParams,
+        InitializeResult, ListResourcesResult, ListResourceTemplatesResult, ListToolsResult,
+        PaginatedRequestParams, RawResource, RawResourceTemplate, ReadResourceRequestParams,
+        ReadResourceResult, Resource, ResourceContents, ResourceTemplate,
+        ResourceUpdatedNotificationParam, ServerInfo, SetLevelRequestParams,
+        SubscribeRequestParams, Tool, UnsubscribeRequestParams,
     },
     schemars,
     serde_json,
@@ -24,7 +25,7 @@ use rmcp::{
     ErrorData, RoleServer,
 };
 use tokio::sync::{broadcast::error::RecvError, RwLock};
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 const ICON_SVG: &[u8] = include_bytes!("../../assets/deluge-mcp-icon.svg");
 const ICON_48: &[u8] = include_bytes!("../../assets/deluge-mcp-icon-48x48.png");
@@ -41,11 +42,25 @@ use crate::rencode::Value;
 #[derive(Clone)]
 pub struct DelugeServer {
     client: Arc<DelugeClient>,
-    enabled_tools: std::collections::HashSet<String>,
+    /// Tools currently visible in `tools/list` and callable via `call_tool`.
+    /// Computed as `user_intent_tools` minus any tools whose required plugin
+    /// is not active on the daemon. Updated live by the plugin watcher.
+    enabled_tools: Arc<StdRwLock<HashSet<String>>>,
+    /// Tools the user has authorised (via defaults or `--enable-tool`).
+    /// Plugin gating is applied on top to produce `enabled_tools`.
+    user_intent_tools: Arc<HashSet<String>>,
+    /// Tools that require the Deluge Label plugin to be enabled on the daemon.
+    plugin_gated_tools: Arc<HashSet<String>>,
+    /// Whether the Label plugin is currently active on the daemon.
+    /// Updated by the plugin watcher; used by `tool_gate` for accurate hints.
+    label_plugin_active: Arc<StdRwLock<bool>>,
     tool_router: ToolRouter<Self>,
     /// Active resource subscriptions: resource URI → connected peer.
     /// One subscriber per URI — last `subscribe` call wins.
     subscribers: Arc<RwLock<HashMap<String, Peer<RoleServer>>>>,
+    /// All connected MCP peers, captured on `initialize`.
+    /// Used to fan out `notifications/tools/list_changed` when plugin state flips.
+    connected_peers: Arc<RwLock<Vec<Peer<RoleServer>>>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -160,6 +175,9 @@ enum TorrentState {
 struct ListTorrentsParams {
     /// Filter by torrent state. Omit to return all torrents.
     state: Option<TorrentState>,
+    /// Filter by Deluge label. Requires the Label plugin to be enabled on the daemon.
+    /// Pass the empty string to filter for unlabeled torrents.
+    label: Option<String>,
     /// Max torrents per page (default: 100).
     limit: Option<usize>,
     /// Torrents to skip (default: 0). Use next_offset from previous response to paginate.
@@ -170,6 +188,64 @@ struct ListTorrentsParams {
 struct PathParams {
     /// Absolute path (file or directory) on the Deluge server to query.
     path: String,
+}
+
+/// Label names use a restricted character set: lowercase letters, digits, '_', '-', and '.'.
+/// Mixed-case input is normalized to lowercase before being sent to Deluge.
+#[derive(Deserialize, schemars::JsonSchema)]
+struct LabelNameParams {
+    /// Label name. Allowed characters: a-z, 0-9, '_', '-', '.'. Will be lowercased.
+    label: String,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct SetTorrentLabelParams {
+    /// Torrent info_hashes to apply the label to.
+    #[schemars(length(min = 1))]
+    info_hashes: Vec<InfoHash>,
+    /// Label to assign. Pass an empty string or "No Label" to clear the torrent's label.
+    /// Otherwise must already exist on the daemon — use deluge_create_label first if it does not.
+    label: String,
+}
+
+/// Per-label default options that Deluge applies to every torrent carrying the label.
+/// Speed values are in KiB/s. Use -1 for unlimited on any numeric field. Omit fields you don't want to change.
+/// Each `apply_*` flag toggles whether the corresponding group of options takes effect:
+/// `apply_max` gates max_download_speed/max_upload_speed/max_connections/max_upload_slots,
+/// `apply_queue` gates is_auto_managed/stop_at_ratio/stop_ratio/remove_at_ratio,
+/// `apply_move_completed` gates move_completed/move_completed_path.
+#[derive(Deserialize, schemars::JsonSchema)]
+struct SetLabelOptionsParams {
+    /// Label to configure. Must already exist on the daemon.
+    label: String,
+    /// Enable the max_* speed and connection limits for torrents carrying this label.
+    apply_max: Option<bool>,
+    /// Max download speed in KiB/s.
+    max_download_speed: Option<f64>,
+    /// Max upload speed in KiB/s.
+    max_upload_speed: Option<f64>,
+    /// Max simultaneous peer connections.
+    max_connections: Option<i64>,
+    /// Max simultaneous upload slots.
+    max_upload_slots: Option<i64>,
+    /// Enable the queue-related options (is_auto_managed, stop/remove-at-ratio).
+    apply_queue: Option<bool>,
+    /// Whether Deluge's queue manager controls the torrent's start/stop state.
+    is_auto_managed: Option<bool>,
+    /// Stop the torrent when its ratio reaches stop_ratio.
+    stop_at_ratio: Option<bool>,
+    /// Seed ratio limit at which the torrent stops (e.g. 2.0 = 200%).
+    stop_ratio: Option<f64>,
+    /// Remove the torrent once stop_ratio is reached.
+    remove_at_ratio: Option<bool>,
+    /// Enable the move-completed options.
+    apply_move_completed: Option<bool>,
+    /// Move files to move_completed_path when download finishes.
+    move_completed: Option<bool>,
+    /// Destination path when move_completed is true.
+    move_completed_path: Option<String>,
+    /// Download first and last pieces first (useful for media previews).
+    prioritize_first_last: Option<bool>,
 }
 
 // ---------------------------------------------------------------------------
@@ -261,21 +337,33 @@ impl DelugeServer {
         let limit = p.limit.unwrap_or(100).max(1);
         let offset = p.offset.unwrap_or(0);
 
-        let filter = match p.state {
-            Some(ref s) => {
-                let state_str = serde_json::to_value(s)
-                    .ok()
-                    .and_then(|v| v.as_str().map(|s| s.to_string()))
-                    .unwrap_or_default();
-                Value::Dict(vec![(
-                    Value::String("state".into()),
-                    Value::String(state_str),
-                )])
-            }
-            None => Value::Dict(vec![]),
-        };
+        let label_plugin_active = *self.label_plugin_active.read().unwrap();
 
-        let keys = Value::List(vec![
+        if p.label.is_some() && !label_plugin_active {
+            return Err(
+                "Cannot filter by label: the Label plugin is not enabled on the Deluge daemon.\n\
+                 [Hint: Ask the user to enable the Label plugin in Deluge's Preferences \u{2192} Plugins.]"
+                    .to_string(),
+            );
+        }
+
+        let mut filter_pairs: Vec<(Value, Value)> = Vec::new();
+        if let Some(ref s) = p.state {
+            let state_str = serde_json::to_value(s)
+                .ok()
+                .and_then(|v| v.as_str().map(|s| s.to_string()))
+                .unwrap_or_default();
+            filter_pairs.push((Value::String("state".into()), Value::String(state_str)));
+        }
+        if let Some(ref label) = p.label {
+            filter_pairs.push((
+                Value::String("label".into()),
+                Value::String(label.clone()),
+            ));
+        }
+        let filter = Value::Dict(filter_pairs);
+
+        let mut keys_list = vec![
             Value::String("name".into()),
             Value::String("state".into()),
             Value::String("progress".into()),
@@ -284,7 +372,11 @@ impl DelugeServer {
             Value::String("upload_payload_rate".into()),
             Value::String("eta".into()),
             Value::String("save_path".into()),
-        ]);
+        ];
+        if label_plugin_active {
+            keys_list.push(Value::String("label".into()));
+        }
+        let keys = Value::List(keys_list);
 
         let result = self.client
             .call("core.get_torrents_status", vec![filter, keys], vec![])
@@ -604,6 +696,209 @@ impl DelugeServer {
             })
             .map_err(Self::enrich_client_error)
     }
+
+    /// Create a new label on the Deluge daemon. Labels are used to group and bulk-operate on torrents.
+    #[tool(name = "deluge_create_label", title = "Create Label", annotations(destructive_hint = false, open_world_hint = false))]
+    async fn create_label(
+        &self,
+        Parameters(p): Parameters<LabelNameParams>,
+    ) -> Result<String, String> {
+        self.tool_gate("deluge_create_label")?;
+        let label = Self::validate_label_name(&p.label)?;
+        self.client
+            .call("label.add", vec![Value::String(label)], vec![])
+            .await
+            .map(|_| "ok".to_string())
+            .map_err(Self::enrich_label_error)
+    }
+
+    /// Delete a label from the Deluge daemon. Torrents previously assigned this label become unlabeled.
+    /// The torrents themselves and their data are not affected.
+    #[tool(name = "deluge_delete_label", title = "Delete Label", annotations(destructive_hint = true, idempotent_hint = false, open_world_hint = false))]
+    async fn delete_label(
+        &self,
+        Parameters(p): Parameters<LabelNameParams>,
+    ) -> Result<String, String> {
+        self.tool_gate("deluge_delete_label")?;
+        let label = Self::validate_label_name(&p.label)?;
+        self.client
+            .call("label.remove", vec![Value::String(label)], vec![])
+            .await
+            .map(|_| "ok".to_string())
+            .map_err(Self::enrich_label_error)
+    }
+
+    /// Assign a label to one or more torrents. A torrent can only have one label at a time.
+    /// PREREQUISITE: The label must already exist — use deluge_create_label first if needed.
+    #[tool(name = "deluge_set_torrent_label", title = "Set Torrent Label", annotations(destructive_hint = false, idempotent_hint = true, open_world_hint = false))]
+    async fn set_torrent_label(
+        &self,
+        Parameters(p): Parameters<SetTorrentLabelParams>,
+    ) -> Result<String, String> {
+        self.tool_gate("deluge_set_torrent_label")?;
+        Self::validate_info_hashes(&p.info_hashes)?;
+        let label = Self::normalize_label_for_set(&p.label)?;
+
+        let create_label_hint = self.create_label_hint();
+        let mut results = serde_json::Map::new();
+        for hash in &p.info_hashes {
+            let result = self
+                .client
+                .call(
+                    "label.set_torrent",
+                    vec![Value::String(hash.0.clone()), Value::String(label.clone())],
+                    vec![],
+                )
+                .await;
+            match result {
+                Ok(_) => {
+                    results.insert(hash.0.clone(), serde_json::json!("ok"));
+                }
+                Err(e) => {
+                    let msg = Self::enrich_label_set_error(e, &label, create_label_hint.as_deref());
+                    results.insert(hash.0.clone(), serde_json::json!({ "error": msg }));
+                }
+            }
+        }
+        if results.len() == 1 {
+            let (_, v) = results.into_iter().next().unwrap();
+            if let Some(s) = v.as_str() {
+                return Ok(s.to_string());
+            }
+            return Err(v["error"].as_str().unwrap_or("unknown error").to_string());
+        }
+        Ok(serde_json::to_string_pretty(&serde_json::Value::Object(results)).unwrap_or_default())
+    }
+
+    /// Pause every torrent assigned the given label. Errors if no torrents currently have this label.
+    #[tool(name = "deluge_pause_label", title = "Pause Label", annotations(destructive_hint = false, idempotent_hint = true, open_world_hint = false))]
+    async fn pause_label(
+        &self,
+        Parameters(p): Parameters<LabelNameParams>,
+    ) -> Result<String, String> {
+        self.tool_gate("deluge_pause_label")?;
+        let label = Self::validate_label_name(&p.label)?;
+        self.bulk_act_on_label(&label, "core.pause_torrents", "paused").await
+    }
+
+    /// Resume every paused torrent assigned the given label. Errors if no torrents currently have this label.
+    #[tool(name = "deluge_resume_label", title = "Resume Label", annotations(destructive_hint = false, idempotent_hint = true, open_world_hint = false))]
+    async fn resume_label(
+        &self,
+        Parameters(p): Parameters<LabelNameParams>,
+    ) -> Result<String, String> {
+        self.tool_gate("deluge_resume_label")?;
+        let label = Self::validate_label_name(&p.label)?;
+        self.bulk_act_on_label(&label, "core.resume_torrents", "resumed").await
+    }
+
+    /// List all labels defined on the Deluge daemon. Returns a JSON array of label names.
+    #[tool(name = "deluge_list_labels", title = "List Labels", annotations(read_only_hint = true, open_world_hint = false))]
+    async fn list_labels(&self) -> Result<String, String> {
+        self.tool_gate("deluge_list_labels")?;
+        let result = self
+            .client
+            .call("label.get_labels", vec![], vec![])
+            .await
+            .map_err(Self::enrich_label_error)?;
+        Ok(Self::value_to_json_string(result))
+    }
+
+    /// Get a label's default options (speed caps, ratio handling, move-completed path, etc.).
+    /// These defaults are applied to every torrent assigned this label.
+    #[tool(name = "deluge_get_label_options", title = "Get Label Options", annotations(read_only_hint = true, open_world_hint = false))]
+    async fn get_label_options(
+        &self,
+        Parameters(p): Parameters<LabelNameParams>,
+    ) -> Result<String, String> {
+        self.tool_gate("deluge_get_label_options")?;
+        let label = Self::validate_label_name(&p.label)?;
+        let result = self
+            .client
+            .call("label.get_options", vec![Value::String(label)], vec![])
+            .await
+            .map_err(Self::enrich_label_error)?;
+        Ok(Self::value_to_json_string(result))
+    }
+
+    /// Set default options on a label. Options are applied to every torrent currently carrying
+    /// the label and to any new torrents assigned the label going forward.
+    #[tool(name = "deluge_set_label_options", title = "Set Label Options", annotations(destructive_hint = false, idempotent_hint = true, open_world_hint = false))]
+    async fn set_label_options(
+        &self,
+        Parameters(p): Parameters<SetLabelOptionsParams>,
+    ) -> Result<String, String> {
+        self.tool_gate("deluge_set_label_options")?;
+        let label = Self::validate_label_name(&p.label)?;
+
+        let mut opts: Vec<(Value, Value)> = Vec::new();
+        if let Some(v) = p.apply_max {
+            opts.push((Value::String("apply_max".into()), Value::Bool(v)));
+        }
+        if let Some(v) = p.max_download_speed {
+            opts.push((Value::String("max_download_speed".into()), Value::Float64(v)));
+        }
+        if let Some(v) = p.max_upload_speed {
+            opts.push((Value::String("max_upload_speed".into()), Value::Float64(v)));
+        }
+        if let Some(v) = p.max_connections {
+            opts.push((Value::String("max_connections".into()), Value::Int(v)));
+        }
+        if let Some(v) = p.max_upload_slots {
+            opts.push((Value::String("max_upload_slots".into()), Value::Int(v)));
+        }
+        if let Some(v) = p.apply_queue {
+            opts.push((Value::String("apply_queue".into()), Value::Bool(v)));
+        }
+        if let Some(v) = p.is_auto_managed {
+            opts.push((Value::String("is_auto_managed".into()), Value::Bool(v)));
+        }
+        if let Some(v) = p.stop_at_ratio {
+            opts.push((Value::String("stop_at_ratio".into()), Value::Bool(v)));
+        }
+        if let Some(v) = p.stop_ratio {
+            opts.push((Value::String("stop_ratio".into()), Value::Float64(v)));
+        }
+        if let Some(v) = p.remove_at_ratio {
+            opts.push((Value::String("remove_at_ratio".into()), Value::Bool(v)));
+        }
+        if let Some(v) = p.apply_move_completed {
+            opts.push((
+                Value::String("apply_move_completed".into()),
+                Value::Bool(v),
+            ));
+        }
+        if let Some(v) = p.move_completed {
+            opts.push((Value::String("move_completed".into()), Value::Bool(v)));
+        }
+        if let Some(v) = p.move_completed_path {
+            opts.push((
+                Value::String("move_completed_path".into()),
+                Value::String(v),
+            ));
+        }
+        if let Some(v) = p.prioritize_first_last {
+            opts.push((
+                Value::String("prioritize_first_last".into()),
+                Value::Bool(v),
+            ));
+        }
+        if opts.is_empty() {
+            return Err(
+                "No options provided. Set at least one option field (e.g. stop_at_ratio, max_download_speed, move_completed_path).".to_string(),
+            );
+        }
+
+        self.client
+            .call(
+                "label.set_options",
+                vec![Value::String(label), Value::Dict(opts)],
+                vec![],
+            )
+            .await
+            .map(|_| "ok".to_string())
+            .map_err(Self::enrich_label_error)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -613,8 +908,13 @@ impl DelugeServer {
 impl DelugeServer {
     pub fn new(
         client: Arc<DelugeClient>,
-        enabled_tools: std::collections::HashSet<String>,
+        user_intent_tools: HashSet<String>,
+        plugin_gated_tools: HashSet<String>,
+        initial_label_plugin_active: bool,
     ) -> Self {
+        let initial_enabled =
+            compute_enabled(&user_intent_tools, &plugin_gated_tools, initial_label_plugin_active);
+
         let subscribers: Arc<RwLock<HashMap<String, Peer<RoleServer>>>> =
             Arc::new(RwLock::new(HashMap::new()));
 
@@ -667,15 +967,108 @@ impl DelugeServer {
 
         Self {
             client,
-            enabled_tools,
+            enabled_tools: Arc::new(StdRwLock::new(initial_enabled)),
+            user_intent_tools: Arc::new(user_intent_tools),
+            plugin_gated_tools: Arc::new(plugin_gated_tools),
+            label_plugin_active: Arc::new(StdRwLock::new(initial_label_plugin_active)),
             tool_router: Self::tool_router(),
             subscribers,
+            connected_peers: Arc::new(RwLock::new(Vec::new())),
         }
     }
 
+    /// Spawn the plugin watcher. Listens for Deluge `PluginEnabled`/`PluginDisabled`
+    /// events for the Label plugin and updates `enabled_tools` accordingly.
+    /// On reconnect or broadcast lag it re-probes via `core.get_enabled_plugins`
+    /// to recover the authoritative state.
+    pub fn spawn_plugin_watcher(&self) {
+        let client = self.client.clone();
+        let user_intent = self.user_intent_tools.clone();
+        let plugin_gated = self.plugin_gated_tools.clone();
+        let enabled_tools = self.enabled_tools.clone();
+        let label_active = self.label_plugin_active.clone();
+        let connected_peers = self.connected_peers.clone();
+        let mut event_rx = client.subscribe_events();
+
+        tokio::spawn(async move {
+            loop {
+                match event_rx.recv().await {
+                    Ok(DelugeEvent::PluginEnabled { name }) if name == "Label" => {
+                        apply_label_state(
+                            true,
+                            &user_intent,
+                            &plugin_gated,
+                            &enabled_tools,
+                            &label_active,
+                            &connected_peers,
+                        )
+                        .await;
+                    }
+                    Ok(DelugeEvent::PluginDisabled { name }) if name == "Label" => {
+                        apply_label_state(
+                            false,
+                            &user_intent,
+                            &plugin_gated,
+                            &enabled_tools,
+                            &label_active,
+                            &connected_peers,
+                        )
+                        .await;
+                    }
+                    Ok(DelugeEvent::Reconnected) => {
+                        // Re-seed from the daemon — the previous state may be stale
+                        // and `set_event_interest` was just re-issued, so we may have
+                        // missed transitions while disconnected.
+                        if let Some(active) = probe_label_plugin(&client).await {
+                            apply_label_state(
+                                active,
+                                &user_intent,
+                                &plugin_gated,
+                                &enabled_tools,
+                                &label_active,
+                                &connected_peers,
+                            )
+                            .await;
+                        }
+                    }
+                    Err(RecvError::Lagged(n)) => {
+                        warn!(
+                            "Plugin watcher lagged by {n} events — re-probing plugin state"
+                        );
+                        if let Some(active) = probe_label_plugin(&client).await {
+                            apply_label_state(
+                                active,
+                                &user_intent,
+                                &plugin_gated,
+                                &enabled_tools,
+                                &label_active,
+                                &connected_peers,
+                            )
+                            .await;
+                        }
+                    }
+                    Err(RecvError::Closed) => break,
+                    _ => {}
+                }
+            }
+        });
+    }
+
     fn tool_gate(&self, tool_name: &str) -> Result<(), String> {
-        if self.enabled_tools.contains(tool_name) {
-            Ok(())
+        if self.enabled_tools.read().unwrap().contains(tool_name) {
+            return Ok(());
+        }
+        // Disabled — pick the right hint based on why.
+        let plugin_gated = self.plugin_gated_tools.contains(tool_name);
+        let plugin_active = *self.label_plugin_active.read().unwrap();
+        if plugin_gated && !plugin_active {
+            Err(format!(
+                "Tool '{tool_name}' is currently unavailable because the Label plugin is not \
+                 enabled on the Deluge daemon.\n\
+                 [Hint: Ask the user to enable the Label plugin in Deluge's \
+                 Preferences \u{2192} Plugins, or via `deluge-console plugin --enable Label`. \
+                 Once enabled the tool becomes available without restarting the MCP server.]"
+            ))
         } else {
             Err(format!(
                 "Tool '{tool_name}' is disabled. Use --enable-tool={tool_name} to enable it.\n\
@@ -865,6 +1258,172 @@ impl DelugeServer {
     fn value_to_json_string(v: Value) -> String {
         serde_json::to_string(&crate::rencode::value_to_json(v)).unwrap_or_default()
     }
+
+    /// Validate and normalize a Deluge label name. Lowercases the input and rejects
+    /// empty strings or characters outside `[a-z0-9_\-\.]`.
+    fn validate_label_name(label: &str) -> Result<String, String> {
+        let trimmed = label.trim();
+        if trimmed.is_empty() {
+            return Err("Label name must not be empty.".to_string());
+        }
+        let lowered = trimmed.to_lowercase();
+        let valid = lowered.chars().all(|c| {
+            c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '_' | '-' | '.')
+        });
+        if !valid {
+            return Err(format!(
+                "Invalid label name '{label}'. Allowed characters: a-z, 0-9, '_', '-', '.'."
+            ));
+        }
+        Ok(lowered)
+    }
+
+    /// Normalize a label for `label.set_torrent`. Empty string and the literal
+    /// sentinel `"No Label"` are passed through unchanged — both clear the torrent's
+    /// label on the daemon. Any other value is validated as a normal label name.
+    fn normalize_label_for_set(label: &str) -> Result<String, String> {
+        if label.is_empty() || label == "No Label" {
+            return Ok(label.to_string());
+        }
+        Self::validate_label_name(label)
+    }
+
+    /// Build a hint that points the LLM to deluge_create_label, but only if that
+    /// tool is currently enabled. Returns `None` otherwise.
+    fn create_label_hint(&self) -> Option<String> {
+        let enabled = self.enabled_tools.read().unwrap();
+        if enabled.contains("deluge_create_label") {
+            Some(
+                "If the label does not exist, create it first with deluge_create_label."
+                    .to_string(),
+            )
+        } else {
+            None
+        }
+    }
+
+    /// Common implementation of pause_label / resume_label. Looks up the torrents
+    /// carrying the label via a server-side filter, errors if none, then forwards
+    /// the hash list to the supplied core action.
+    async fn bulk_act_on_label(
+        &self,
+        label: &str,
+        action_method: &str,
+        action_past_tense: &str,
+    ) -> Result<String, String> {
+        let filter = Value::Dict(vec![(
+            Value::String("label".into()),
+            Value::String(label.to_string()),
+        )]);
+        let keys = Value::List(vec![Value::String("label".into())]);
+        let status = self
+            .client
+            .call("core.get_torrents_status", vec![filter, keys], vec![])
+            .await
+            .map_err(Self::enrich_client_error)?;
+
+        let hashes: Vec<String> = match status {
+            Value::Dict(pairs) => pairs
+                .into_iter()
+                .filter_map(|(k, _)| match k {
+                    Value::String(s) => Some(s),
+                    _ => None,
+                })
+                .collect(),
+            other => {
+                return Err(format!(
+                    "Unexpected response from core.get_torrents_status: {other:?}"
+                ));
+            }
+        };
+
+        if hashes.is_empty() {
+            return Err(format!(
+                "No torrents have label '{label}'.\n\
+                 [Hint: Use deluge_list_torrents to see which labels are in use, \
+                 or pick a different label.]"
+            ));
+        }
+
+        let count = hashes.len();
+        let hash_values: Vec<Value> =
+            hashes.iter().cloned().map(Value::String).collect();
+
+        self.client
+            .call(action_method, vec![Value::List(hash_values)], vec![])
+            .await
+            .map_err(Self::enrich_client_error)?;
+
+        let out = serde_json::json!({
+            "label": label,
+            "action": action_past_tense,
+            "count": count,
+            "info_hashes": hashes,
+        });
+        Ok(serde_json::to_string_pretty(&out).unwrap_or_default())
+    }
+
+    /// Map common label.* RPC errors to actionable messages. Keeps the raw exception
+    /// text so the LLM has full context, then appends a [Hint: ...] for known cases.
+    fn enrich_label_error(e: anyhow::Error) -> String {
+        let msg = e.to_string();
+        let hint = if msg.contains("Unknown Label") {
+            Some(
+                "The label does not exist on the Deluge daemon. \
+                 Use deluge_list_torrents to discover labels in use, or create the label first.",
+            )
+        } else if msg.contains("Label already exists") {
+            Some(
+                "A label with this name already exists. \
+                 No action needed if you intended to use the existing label.",
+            )
+        } else if msg.contains("Empty Label") || msg.contains("Invalid label") {
+            Some(
+                "Deluge rejected the label name. \
+                 Allowed characters: a-z, 0-9, '_', '-', '.'.",
+            )
+        } else if msg.contains("KeyError")
+            && (msg.contains("label.") || msg.contains("'label.'"))
+        {
+            Some(
+                "The Label plugin appears to be disabled on the Deluge daemon — \
+                 the label.* RPC methods are unregistered. \
+                 The MCP server will hide label tools shortly.",
+            )
+        } else {
+            None
+        };
+        match hint {
+            Some(h) => format!("{msg}\n[Hint: {h}]"),
+            None => msg,
+        }
+    }
+
+    /// Specialized error handling for `label.set_torrent`. If the label is missing
+    /// and `deluge_create_label` is currently enabled, suggest using it.
+    fn enrich_label_set_error(
+        e: anyhow::Error,
+        label: &str,
+        create_hint: Option<&str>,
+    ) -> String {
+        let msg = e.to_string();
+        if msg.contains("Unknown Label") {
+            let mut out = format!(
+                "Label '{label}' does not exist on the Deluge daemon. ({msg})"
+            );
+            if let Some(hint) = create_hint {
+                out.push_str(&format!("\n[Hint: {hint}]"));
+            } else {
+                out.push_str(
+                    "\n[Hint: Ask the user to create the label in Deluge first, \
+                     or to enable the create_label MCP tool.]",
+                );
+            }
+            out
+        } else {
+            Self::enrich_label_error(e)
+        }
+    }
 }
 
 /// Map a Deluge push event to the resource URIs that should be notified.
@@ -882,8 +1441,92 @@ fn event_to_resource_uris(event: &DelugeEvent) -> Vec<String> {
         DelugeEvent::TorrentStorageMoved { info_hash, .. } => with_list(info_hash),
         DelugeEvent::TorrentFileRenamed { info_hash, .. } => vec![torrent_uri(info_hash)],
         DelugeEvent::TorrentFolderRenamed { info_hash, .. } => vec![torrent_uri(info_hash)],
-        DelugeEvent::Unknown { .. } => vec![],
+        DelugeEvent::PluginEnabled { .. }
+        | DelugeEvent::PluginDisabled { .. }
+        | DelugeEvent::Reconnected
+        | DelugeEvent::Unknown { .. } => vec![],
     }
+}
+
+// ---------------------------------------------------------------------------
+// Plugin watcher helpers
+// ---------------------------------------------------------------------------
+
+/// Compute the set of tools currently enabled given user intent and plugin state.
+fn compute_enabled(
+    user_intent: &HashSet<String>,
+    plugin_gated: &HashSet<String>,
+    label_plugin_active: bool,
+) -> HashSet<String> {
+    let mut out = user_intent.clone();
+    if !label_plugin_active {
+        for t in plugin_gated {
+            out.remove(t);
+        }
+    }
+    out
+}
+
+/// Probe the Deluge daemon for whether the Label plugin is currently enabled.
+/// Returns `None` on RPC failure (caller should keep the previous state).
+pub async fn probe_label_plugin(client: &Arc<DelugeClient>) -> Option<bool> {
+    match client.call("core.get_enabled_plugins", vec![], vec![]).await {
+        Ok(Value::List(items)) => Some(items.iter().any(
+            |v| matches!(v, Value::String(s) if s == "Label"),
+        )),
+        Ok(other) => {
+            warn!("core.get_enabled_plugins returned unexpected shape: {other:?}");
+            None
+        }
+        Err(e) => {
+            warn!("core.get_enabled_plugins failed: {e}");
+            None
+        }
+    }
+}
+
+/// Apply a new Label-plugin state. If it actually changes the visible tool set,
+/// updates the lock-protected state and fans out `tools/list_changed` to every
+/// connected peer. Stale peers (those whose send fails) are pruned.
+async fn apply_label_state(
+    active: bool,
+    user_intent: &Arc<HashSet<String>>,
+    plugin_gated: &Arc<HashSet<String>>,
+    enabled_tools: &Arc<StdRwLock<HashSet<String>>>,
+    label_active: &Arc<StdRwLock<bool>>,
+    connected_peers: &Arc<RwLock<Vec<Peer<RoleServer>>>>,
+) {
+    let new_set = compute_enabled(user_intent, plugin_gated, active);
+
+    let changed = {
+        let mut current_active = label_active.write().unwrap();
+        let mut current_set = enabled_tools.write().unwrap();
+        let active_changed = *current_active != active;
+        let set_changed = *current_set != new_set;
+        *current_active = active;
+        *current_set = new_set;
+        active_changed || set_changed
+    };
+
+    if !changed {
+        return;
+    }
+
+    info!(
+        "Label plugin is now {} on the Deluge daemon — tool list updated",
+        if active { "enabled" } else { "disabled" }
+    );
+
+    // Fan out tools/list_changed. Prune peers whose notify fails (closed sessions).
+    let peers_snapshot: Vec<Peer<RoleServer>> = connected_peers.read().await.clone();
+    let mut survivors: Vec<Peer<RoleServer>> = Vec::with_capacity(peers_snapshot.len());
+    for peer in peers_snapshot {
+        match peer.notify_tool_list_changed().await {
+            Ok(()) => survivors.push(peer),
+            Err(e) => debug!("notify_tool_list_changed failed for a peer: {e}"),
+        }
+    }
+    *connected_peers.write().await = survivors;
 }
 
 // ---------------------------------------------------------------------------
@@ -906,6 +1549,7 @@ impl ServerHandler for DelugeServer {
         ServerInfo::new(
             rmcp::model::ServerCapabilities::builder()
                 .enable_tools()
+                .enable_tool_list_changed()
                 .enable_resources()
                 .enable_resources_subscribe()
                 .enable_logging()
@@ -917,16 +1561,30 @@ impl ServerHandler for DelugeServer {
             )
     }
 
+    async fn initialize(
+        &self,
+        request: InitializeRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<InitializeResult, ErrorData> {
+        if context.peer.peer_info().is_none() {
+            context.peer.set_peer_info(request);
+        }
+        // Track this peer so the plugin watcher can deliver tools/list_changed.
+        self.connected_peers.write().await.push(context.peer.clone());
+        Ok(self.get_info())
+    }
+
     async fn list_tools(
         &self,
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, ErrorData> {
+        let enabled = self.enabled_tools.read().unwrap().clone();
         let tools: Vec<Tool> = self
             .tool_router
             .list_all()
             .into_iter()
-            .filter(|t| self.enabled_tools.contains(t.name.as_ref()))
+            .filter(|t| enabled.contains(t.name.as_ref()))
             .collect();
         Ok(ListToolsResult { tools, meta: None, next_cursor: None })
     }
@@ -1161,5 +1819,43 @@ mod tests {
         assert!(!DelugeServer::looks_like_file_path("magnet:?xt=urn:btih:abc"));
         assert!(!DelugeServer::looks_like_file_path("aGVsbG8="));
         assert!(!DelugeServer::looks_like_file_path("some random string"));
+    }
+
+    #[test]
+    fn validate_label_name_accepts_valid_labels() {
+        assert_eq!(DelugeServer::validate_label_name("movies").unwrap(), "movies");
+        assert_eq!(DelugeServer::validate_label_name("tv.shows").unwrap(), "tv.shows");
+        assert_eq!(
+            DelugeServer::validate_label_name("2024_backup").unwrap(),
+            "2024_backup"
+        );
+        assert_eq!(DelugeServer::validate_label_name("a-b-c").unwrap(), "a-b-c");
+        // Lowercased
+        assert_eq!(DelugeServer::validate_label_name("Movies").unwrap(), "movies");
+        // Trimmed
+        assert_eq!(DelugeServer::validate_label_name("  movies  ").unwrap(), "movies");
+    }
+
+    #[test]
+    fn validate_label_name_rejects_invalid_labels() {
+        assert!(DelugeServer::validate_label_name("").is_err());
+        assert!(DelugeServer::validate_label_name("   ").is_err());
+        // Space is not allowed — "No Label" lowercases to "no label" which still has a space
+        assert!(DelugeServer::validate_label_name("No Label").is_err());
+        assert!(DelugeServer::validate_label_name("has space").is_err());
+        assert!(DelugeServer::validate_label_name("emoji\u{1F3AC}").is_err());
+        assert!(DelugeServer::validate_label_name("slash/here").is_err());
+    }
+
+    #[test]
+    fn normalize_label_for_set_passes_clear_sentinels() {
+        assert_eq!(DelugeServer::normalize_label_for_set("").unwrap(), "");
+        assert_eq!(
+            DelugeServer::normalize_label_for_set("No Label").unwrap(),
+            "No Label"
+        );
+        // Anything else goes through normal validation
+        assert_eq!(DelugeServer::normalize_label_for_set("Movies").unwrap(), "movies");
+        assert!(DelugeServer::normalize_label_for_set("bad name").is_err());
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -991,6 +991,23 @@ impl DelugeServer {
         let mut event_rx = client.subscribe_events();
 
         tokio::spawn(async move {
+            // Seed from an authoritative probe. The constructor's
+            // `initial_label_plugin_active` may be stale (e.g. captured at
+            // process start but the plugin toggled before this HTTP session
+            // opened), and the broadcast receiver was created above — any
+            // events that arrive between here and the loop will be buffered.
+            if let Some(active) = probe_label_plugin(&client).await {
+                apply_label_state(
+                    active,
+                    &user_intent,
+                    &plugin_gated,
+                    &enabled_tools,
+                    &label_active,
+                    &connected_peers,
+                )
+                .await;
+            }
+
             loop {
                 match event_rx.recv().await {
                     Ok(DelugeEvent::PluginEnabled { name }) if name == "Label" => {
@@ -1058,7 +1075,19 @@ impl DelugeServer {
         if self.enabled_tools.read().unwrap().contains(tool_name) {
             return Ok(());
         }
-        // Disabled — pick the right hint based on why.
+        // Disabled — pick the right hint based on why. CLI intent wins: if the
+        // operator did not opt into this tool via defaults or `--enable-tool`,
+        // the plugin hint is misleading (enabling the plugin alone won't make
+        // the tool visible).
+        if !self.user_intent_tools.contains(tool_name) {
+            return Err(format!(
+                "Tool '{tool_name}' is disabled. Use --enable-tool={tool_name} to enable it.\n\
+                 [Hint: This tool has been administratively disabled on this server. \
+                 Do not attempt this operation by other means — inform the user that the \
+                 server must be restarted with --enable-tool={tool_name} to allow this action.]"
+            ));
+        }
+        // User intended this tool; it must be gated by an inactive plugin.
         let plugin_gated = self.plugin_gated_tools.contains(tool_name);
         let plugin_active = *self.label_plugin_active.read().unwrap();
         if plugin_gated && !plugin_active {
@@ -1517,16 +1546,28 @@ async fn apply_label_state(
         if active { "enabled" } else { "disabled" }
     );
 
-    // Fan out tools/list_changed. Prune peers whose notify fails (closed sessions).
+    // Fan out tools/list_changed. Prune peers whose notify fails (closed
+    // sessions) while preserving any peers added concurrently via initialize()
+    // between the snapshot and the prune. `connected_peers` is append-only
+    // outside this function, so positions 0..snapshot_len correspond to the
+    // snapshot and positions >= snapshot_len are new arrivals we must keep.
     let peers_snapshot: Vec<Peer<RoleServer>> = connected_peers.read().await.clone();
-    let mut survivors: Vec<Peer<RoleServer>> = Vec::with_capacity(peers_snapshot.len());
-    for peer in peers_snapshot {
+    let snapshot_len = peers_snapshot.len();
+    let mut success = vec![false; snapshot_len];
+    for (i, peer) in peers_snapshot.iter().enumerate() {
         match peer.notify_tool_list_changed().await {
-            Ok(()) => survivors.push(peer),
+            Ok(()) => success[i] = true,
             Err(e) => debug!("notify_tool_list_changed failed for a peer: {e}"),
         }
     }
-    *connected_peers.write().await = survivors;
+
+    let mut peers = connected_peers.write().await;
+    let current = std::mem::take(&mut *peers);
+    for (i, peer) in current.into_iter().enumerate() {
+        if i >= snapshot_len || success[i] {
+            peers.push(peer);
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Exposes eight new MCP tools wrapping Deluge's Label plugin RPC surface: `list_labels`, `create_label`, `delete_label`, `set_torrent_label`, `pause_label`, `resume_label`, `get_label_options`, `set_label_options`. `list_torrents` also gains an optional `label` filter and returns each torrent's label when the plugin is active.
- Tools are dynamically shown or hidden based on whether the Label plugin is enabled on the daemon. The server subscribes to Deluge's `PluginEnabledEvent` / `PluginDisabledEvent` push events and fires `notifications/tools/list_changed` to connected peers within seconds of any toggle — no MCP server restart needed. Re-seeds on reconnect and on broadcast lag as belt-and-suspenders.
- Safety gates extended: `create_label`, `delete_label`, and `set_label_options` are default-disabled (require `--enable-tool`). The other five label tools are default-enabled when the plugin is active. `--enable-tool` cannot override plugin gating.

## Test plan

- [ ] `cargo build` and `cargo test` pass
- [ ] `--list-tools` shows the new PLUGIN column and correctly marks the eight label tools
- [ ] Start server against a daemon with the Label plugin **disabled**: label tools are absent from `tools/list`
- [ ] Enable the Label plugin in a Deluge client (GTK / Web UI / `deluge-console plugin --enable Label`): `tools/list_changed` fires and label tools appear within seconds
- [ ] Disable the plugin again: tools disappear the same way
- [ ] `list_torrents` with a `label` filter returns only matching torrents when the plugin is active, and errors cleanly when it is not
- [ ] `create_label` / `delete_label` / `set_label_options` are hidden unless explicitly enabled via `--enable-tool`
- [ ] Security review completed — no PR-introduced findings at MEDIUM or above

🤖 Generated with [Claude Code](https://claude.com/claude-code)