### PR TITLE
Default to minified responses; rename shape token to `defaults`; README overhaul (0.9.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,8 +159,8 @@ By default OAuth state is held in memory only — every registered client, acces
 An MCP client can declare what kind of consumer it is — a token-sensitive LLM or a byte/parse-sensitive programmatic tool — and receive a JSON payload shaped for it. The configuration is one canonical DSL, parsed by one function (`src/response_config`), and used on both transports:
 
 ```
-HTTP:   POST /mcp/<format>?<params>     e.g. /mcp/json?shape=minified,sparse
-STDIO:  --response-config '<format>?<params>'   e.g. --response-config 'json?shape=minified,sparse'
+HTTP:   POST /mcp/<format>?<params>     e.g. /mcp/json?shape=minified,defaults
+STDIO:  --response-config '<format>?<params>'   e.g. --response-config 'json?shape=minified,defaults'
         (or DELUGE_RESPONSE_CONFIG)
 ```
 
@@ -170,14 +170,14 @@ The **path segment names the payload format** (the encoding namespace — `json`
 
 | Param | Values | Default | Effect |
 |---|---|---|---|
-| `shape` | `pretty`, `minified`, `sparse` (CSV; `pretty`/`minified` mutually exclusive) | `minified` | Whitespace + redundancy. `sparse` emits a one-time `defaults` block and omits per-row default-valued fields from `list_torrents`-shaped output (reconstruct a row as `{...defaults, ...row}`). |
+| `shape` | `pretty`, `minified`, `defaults` (CSV; `pretty`/`minified` mutually exclusive) | `minified` | Whitespace + redundancy. `defaults` emits a one-time `defaults` block and omits per-row default-valued fields from `list_torrents`-shaped output (reconstruct a row as `{...defaults, ...row}`). |
 | `ids` | `full` | `full` | Selects an `IdStrategy` (`src/ids`). v1 ships `Full` (the id is the 40/64-hex info hash) only. |
 
 **Defaults**: plain `/mcp`, `/mcp/json` with no params, and STDIO without the flag all produce **minified** output — compact output suits the LLM clients that are the common consumer. Human-readable output is opt-in via `shape=pretty`. An unknown format or invalid parameter is a hard error — `400 Bad Request` on HTTP, non-zero exit at STDIO startup.
 
 **How config reaches a tool**: rmcp's per-session service factory takes no request data, so config is resolved **per request**, not per session. On HTTP, `response_config_layer` (middleware on the `/mcp` routes, outside `nest_service` so it sees the pre-strip path) parses the path+query and inserts a `ResponseConfig` into the request extensions; rmcp copies the `http::request::Parts` into each tool call's `RequestContext`, and `DelugeServer::resolve_config` reads it back, falling back to the startup/STDIO config when absent. Tool handlers serialize via `DelugeServer::shape(value, &ctx)`. See ADR-0012.
 
-**Scope (v1)**: shaping applies to all JSON the server emits — tool outputs, MCP resource reads (`deluge://torrents`, `deluge://torrent/<hash>`), and the `--test-connection` session-status diagnostic (which doubles as a demonstration that the shaping switches are in effect). The `deluge://torrents` resource is emitted in the `{"torrents": {...}}` envelope so `sparse` elides default-valued fields there exactly as for `list_torrents`. `sparse` remains a structural no-op on the single-torrent resource and the diagnostic (they aren't that envelope); `minified`/`pretty` apply everywhere. Not yet built but designed-for: `ids=short` prefix/ephemeral strategies, a `resolve_ids` tool, `toon`/`xml` formats, and `fields=` projection.
+**Scope (v1)**: shaping applies to all JSON the server emits — tool outputs, MCP resource reads (`deluge://torrents`, `deluge://torrent/<hash>`), and the `--test-connection` session-status diagnostic (which doubles as a demonstration that the shaping switches are in effect). The `deluge://torrents` resource is emitted in the `{"torrents": {...}}` envelope so `defaults` elides default-valued fields there exactly as for `list_torrents`. `defaults` remains a structural no-op on the single-torrent resource and the diagnostic (they aren't that envelope); `minified`/`pretty` apply everywhere. Not yet built but designed-for: `ids=short` prefix/ephemeral strategies, a `resolve_ids` tool, `toon`/`xml` formats, and `fields=` projection.
 
 ## File Structure
 
@@ -189,7 +189,7 @@ The **path segment names the payload format** (the encoding namespace — `json`
 | `src/main.rs` | Entry point — CLI arg parsing, transport selection, server startup, HTTP auth + response-config middleware. |
 | `src/rencode.rs` | Internal rencode serializer/deserializer (Deluge wire format). |
 | `src/response_config/mod.rs` | The consumer-shaped-response DSL — `ResponseConfig`, the shared parser (HTTP path+query and STDIO flag), parse errors. |
-| `src/response_config/shape.rs` | Pure JSON shaping transform — minified/pretty serialization and the sparse (`defaults` block + omit) transform. |
+| `src/response_config/shape.rs` | Pure JSON shaping transform — minified/pretty serialization and the `defaults` (defaults-block + omit) transform. |
 | `src/ids/mod.rs` | The `IdStrategy` seam — `encode`/`decode`/`describe` trait with the v1 `Full` (info-hash-is-id) implementation. |
 | `src/deluge/mod.rs` | Deluge RPC client — TLS connection, cert fingerprint logging/pinning, auth, request multiplexing, zlib framing. |
 | `src/tools/mod.rs` | MCP tool implementations — all 21 tools, safety gate helpers, plugin watcher, Value→JSON conversion. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,10 +170,10 @@ The **path segment names the payload format** (the encoding namespace — `json`
 
 | Param | Values | Default | Effect |
 |---|---|---|---|
-| `shape` | `pretty`, `minified`, `sparse` (CSV; `pretty`/`minified` mutually exclusive) | `pretty` | Whitespace + redundancy. `sparse` emits a one-time `defaults` block and omits per-row default-valued fields from `list_torrents`-shaped output (reconstruct a row as `{...defaults, ...row}`). |
+| `shape` | `pretty`, `minified`, `sparse` (CSV; `pretty`/`minified` mutually exclusive) | `minified` | Whitespace + redundancy. `sparse` emits a one-time `defaults` block and omits per-row default-valued fields from `list_torrents`-shaped output (reconstruct a row as `{...defaults, ...row}`). |
 | `ids` | `full` | `full` | Selects an `IdStrategy` (`src/ids`). v1 ships `Full` (the id is the 40/64-hex info hash) only. |
 
-**Defaults and back-compat**: plain `/mcp`, `/mcp/json` with no params, and STDIO without the flag all produce today's pretty output. All token-saving shaping is strictly opt-in. An unknown format or invalid parameter is a hard error — `400 Bad Request` on HTTP, non-zero exit at STDIO startup.
+**Defaults**: plain `/mcp`, `/mcp/json` with no params, and STDIO without the flag all produce **minified** output — compact output suits the LLM clients that are the common consumer. Human-readable output is opt-in via `shape=pretty`. An unknown format or invalid parameter is a hard error — `400 Bad Request` on HTTP, non-zero exit at STDIO startup.
 
 **How config reaches a tool**: rmcp's per-session service factory takes no request data, so config is resolved **per request**, not per session. On HTTP, `response_config_layer` (middleware on the `/mcp` routes, outside `nest_service` so it sees the pre-strip path) parses the path+query and inserts a `ResponseConfig` into the request extensions; rmcp copies the `http::request::Parts` into each tool call's `RequestContext`, and `DelugeServer::resolve_config` reads it back, falling back to the startup/STDIO config when absent. Tool handlers serialize via `DelugeServer::shape(value, &ctx)`. See ADR-0012.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "deluge-torrent-mcp"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deluge-torrent-mcp"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "MIT"
 authors = ["Sandy McArthur, Jr."]

--- a/README.md
+++ b/README.md
@@ -2,21 +2,38 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-A Model Context Protocol (MCP) server written in Rust that bridges AI assistants (like Claude) to a Deluge torrent daemon (`deluged`).
+A Model Context Protocol (MCP) server that bridges AI assistants (like Claude) to a Deluge torrent daemon (`deluged`).
 
-By integrating this server, your AI assistant can seamlessly manage your torrents — adding, pausing, listing, checking statuses, and managing files — all over Deluge's native TCP RPC protocol.
+It exposes torrent management — adding, removing, listing, status queries, pause/resume, label organization, and file operations — as MCP tools, communicating with `deluged` over its native TCP RPC protocol.
 
-## Features
+---
 
-- **Native RPC Integration**: Uses Deluge's native binary protocol (rencode/zlib over TLS) rather than relying on the WebUI API.
-- **Granular Safety Gates**: Prevents LLM hallucinations from accidentally deleting or moving your files. Risky tools are disabled by default and enabled individually via `--enable-tool`.
-- **Dynamic Label Plugin Support**: Exposes tools for Deluge's built-in Label plugin — create, delete, and list labels; assign labels to torrents; pause/resume by label; read and write per-label option defaults. Tools appear and disappear automatically as the plugin is enabled or disabled on the daemon, with no MCP server restart needed.
-- **Flexible TLS Handling**: Seamlessly handles Deluge's default self-signed certificates with a secure, copy-paste pinning mechanism.
-- **Dual Transports**: Supports stdio (for local Claude Desktop use) and HTTP/SSE (for remote agentic frameworks).
+## Overview
 
-## Installation
+An AI-controllable interface to a running Deluge daemon, with guardrails. The server exposes 21 tools covering the full torrent lifecycle:
 
-Ensure you have Rust and Cargo installed, then build the release binary:
+- **Manage torrents** — add (magnet, URL, or `.torrent` file — auto-detected), remove, list, pause, resume, set options, and read detailed status.
+- **File Management** of torrents and files in them on the filesystem (must be enabled) — move storage, rename folders/files, force a recheck, and query free space / path size.
+- **Organize with labels** — list/create/delete labels, assign them, pause/resume a whole label at once, and read or write per-label option defaults. Label tools appear automatically when Deluge's **Label** plugin is enabled.
+
+Key properties:
+
+- **Safety gates** — tools that can delete data or rewrite paths are **disabled by default** and must be turned on individually, so a hallucinating model can't wreck your library.
+- **Two transports** — **stdio** for a local client like Claude Desktop, and **HTTP/SSE** for a network-accessible, always-on server with optional token or OAuth 2.1 authentication.
+- **Configurable response shaping** — per-client JSON formatting (minified and/or sparse to balance token count vs reasoning abilities) on both transports, with more encodings planned.
+- **Flexible TLS** — works out of the box with Deluge's default self-signed certificate, log lines provide an easy copy-paste pinning mechanism for pinning to a cert.
+- **Native RPC** — speaks Deluge's binary protocol (rencode/zlib over TLS) directly, deluged thinks it's another client.
+
+**What you'll need:**
+
+- A reachable running **Deluge 2.x** daemon (`deluged`) with the RPC interface reachable, and its RPC credentials (see [Credentials](#credentials)).
+- **Rust and Cargo** to build the binary (see [Install](#install)).
+
+---
+
+## Install
+
+This MCP server is distributed as source until matured. Build a release binary with Cargo (you'll need [git](https://git-scm.com/install/) and [Rust and Cargo](https://rustup.rs/)):
 
 ```bash
 git clone https://github.com/sandymac/deluge-torrent-mcp.git
@@ -24,102 +41,86 @@ cd deluge-torrent-mcp
 cargo build --release
 ```
 
-The compiled binary will be located at `target/release/deluge-torrent-mcp`.
+The compiled binary lands at `target/release/deluge-torrent-mcp`.
 
-## Claude Desktop Configuration
-
-To use this with Claude Desktop, add it to your `claude_desktop_config.json` file.
-
-- **Mac**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-
-Add the following configuration, using the absolute path to the compiled binary and your Deluge RPC credentials (often found in `~/.config/deluge/auth`):
-
-```json
-{
-  "mcpServers": {
-    "deluge": {
-      "command": "/absolute/path/to/target/release/deluge-torrent-mcp",
-      "args": [
-        "--host", "127.0.0.1",
-        "--port", "58846",
-        "-u", "localclient",
-        "-p", "your_rpc_password"
-      ]
-    }
-  }
-}
-```
-
-> Restart Claude Desktop after updating this configuration.
-
-## CLI Usage & Options
-
-You can run the server directly to test arguments or use it with other MCP clients.
+Sanity-check the build without touching a daemon — `--list-tools` prints the tool inventory and exits before connecting:
 
 ```bash
-deluge-torrent-mcp --host 192.168.1.50 --port 58846 -u admin -p secret [OPTIONS]
+./target/release/deluge-torrent-mcp --list-tools
 ```
 
-| Flag | Env Variable | Default | Description |
-|---|---|---|---|
-| `--host <HOST>` | `DELUGE_HOST` | `127.0.0.1` | Deluge daemon hostname or IP (IPv6: bare address, e.g. `::1`) |
-| `--port <PORT>` | `DELUGE_PORT` | `58846` | Deluge RPC port |
-| `-u, --username <USER>` | `DELUGE_USERNAME` | — | Deluge RPC username |
-| `-p, --password <PASS>` | `DELUGE_PASSWORD` | — | Deluge RPC password |
-| `--enable-tool <PATTERN>` | — | — | Enable tools matching pattern (min 3 chars, substring match). Repeatable, comma-separated |
-| `--disable-tool <PATTERN>` | — | — | Disable tools matching pattern. Flags are processed in order; last wins |
-| `--list-tools` | — | off | Print all tools with their default enabled/disabled state and exit |
-| `--cert-fingerprint <SHA256>` | — | — | Pin the Deluge TLS certificate by fingerprint |
-| `--transport <stdio\|http>` | — | `stdio` | MCP transport to use |
-| `--http-bind <ADDR>` | — | `0.0.0.0:8080` | Bind address for HTTP transport (IPv6: bracket notation, e.g. `[::]:8080`) |
-| `--api-token <TOKEN>` | `DELUGE_API_TOKEN` | — | Bearer token required for HTTP requests |
-| `--test-connection` | — | off | Connect, print session status, and exit |
+---
 
-> Prefer environment variables over CLI flags for credentials to avoid passwords appearing in shell history.
+## Configuration
 
-## Safety Gates
+The server talks to your Deluge daemon the same way regardless of transport — what differs is how your AI client reaches the server:
 
-By default, the server runs in **Safe Mode** — the AI can list, add, pause, and resume torrents, but cannot alter the filesystem, remove torrents, or mutate the label set. Eight tools are disabled by default:
+- **stdio** — the client launches the server as a child process on demand and talks to it over stdin/stdout. Best for a single local client like Claude Desktop. No network exposure, no auth to manage.
+- **HTTP/SSE** — you run the server as a long-lived process and clients connect over the network to `http://<host>:<port>/mcp`. Best for remote access, multiple clients, or agentic frameworks. Protect it with a bearer token or OAuth (see [Client Setup](#client-setup)).
 
-| Tool | Reason |
+**Quick start — stdio:** 
+
+```bash
+DELUGE_USERNAME=admin DELUGE_PASSWORD=secret ./deluge-torrent-mcp
+```
+
+**Quick start — HTTP, listening on the LAN:**
+
+```bash
+DELUGE_USERNAME=admin DELUGE_PASSWORD=secret DELUGE_API_TOKEN=your-secret-token \
+  ./deluge-torrent-mcp --transport http --http-bind 0.0.0.0:8080
+```
+
+Both connect to a Deluge daemon at `127.0.0.1:58846` by default. Point elsewhere with `--host`/`--port`. The sections below cover everything you can tune; the full flag list is in the [CLI reference](#cli-reference).
+
+### Credentials
+
+The MCP server authenticates to Deluge with an RPC username and password. On the daemon these live in Deluge's `auth` file — typically `~/.config/deluge/auth` (or `/config/auth` in many Docker images) — as `username:password:level` lines.
+
+Supply them by flag (`-u`/`-p`) or, preferably, by environment variable (`DELUGE_USERNAME` / `DELUGE_PASSWORD`):
+
+> **Prefer environment variables for credentials.** Passwords passed as CLI flags show up in process listings (`ps`); environment variables don't.
+
+### Safety gates
+
+By default the server runs in a **safe mode**: the AI can list, add, pause, and resume torrents, but cannot alter the filesystem, remove torrents, or mutate the label set. The following tools are disabled until you explicitly turn them on:
+
+| Tool | Why it's off by default |
 |---|---|
 | `move_storage` | Moves files on disk |
 | `rename_folder` | Modifies filesystem paths |
 | `rename_files` | Modifies filesystem paths |
 | `force_recheck` | Interrupts active downloads |
 | `remove_torrent` | Can permanently delete downloaded data |
-| `create_label` | Mutates label set on the daemon |
+| `create_label` | Mutates the label set on the daemon |
 | `delete_label` | Removes labels (destructive) |
 | `set_label_options` | Rewrites per-label default options (speed caps, move-completed path, etc.) |
 
-Use `--list-tools` to see the full list and current defaults:
+See the full inventory and current state with:
 
 ```bash
 deluge-torrent-mcp --list-tools
 ```
 
-Enable tools by name or substring pattern (minimum 3 characters). Flags are processed in order — later flags override earlier ones:
+Turn tools on or off by name or substring pattern (minimum 3 characters). Flags are processed in order, so a later flag overrides an earlier one:
 
 ```bash
 # Enable a single tool
-deluge-torrent-mcp -u admin -p secret --enable-tool move_storage
+deluge-torrent-mcp --enable-tool move_storage
 
-# Enable multiple tools
-deluge-torrent-mcp -u admin -p secret --enable-tools=move_storage,rename_folder,rename_files
+# Enable several at once (comma-separated)
+deluge-torrent-mcp --enable-tools=move_storage,rename_folder,rename_files
 
-# Enable all five disabled-by-default tools
-deluge-torrent-mcp -u admin -p secret --enable-tools=move_storage,rename_folder,rename_files,force_recheck,remove_torrent
-
-# Enable all storage tools, then selectively disable remove
-deluge-torrent-mcp -u admin -p secret --enable-tools=move_storage,rename_folder,rename_files,force_recheck,remove_torrent --disable-tool remove_torrent
+# Enable everything risky, then carve out the most dangerous one
+deluge-torrent-mcp --enable-tools=move_storage,rename_folder,rename_files,force_recheck,remove_torrent \
+  --disable-tool remove_torrent
 ```
 
-When a disabled tool is called, the server returns an error to the AI describing the exact flag needed to enable it.
+When the AI calls a disabled tool, the server returns an error naming the exact flag needed to enable it.
 
-## Label Plugin
+### Label plugin
 
-Deluge ships a built-in **Label** plugin for grouping and bulk-operating on torrents. When the plugin is enabled on the daemon, the MCP server exposes eight label-aware tools:
+Deluge ships a built-in **Label** plugin for grouping and bulk-operating on torrents. When it's enabled on the daemon, the server exposes eight label-aware tools:
 
 | Tool | Default |
 |---|---|
@@ -134,44 +135,153 @@ Deluge ships a built-in **Label** plugin for grouping and bulk-operating on torr
 
 `list_torrents` accepts filters for `state`, `label` (when the plugin is active), `name_contains` (case-insensitive substring, pushed to Deluge's native server-side `name` filter), and `save_path_contains` (case-insensitive substring, applied client-side). It also accepts `sort_by` (one of `name`, `save_path`, `progress`, `total_size`, `download_payload_rate`, `upload_payload_rate`, `eta`, `time_added`, `ratio`) and `sort_order` (`asc` or `desc`). Filters apply before pagination so `total` reflects the filtered count. When the plugin is active, each returned torrent also includes its `label`.
 
-Because `--enable-tool` matches any substring of a tool name, a single `--enable-tool=label` enables every label tool at once (including the default-disabled `create_label`, `delete_label`, and `set_label_options`). Use more specific patterns — e.g. `--enable-tool=create_label` — to enable only one.
+> **Watch the substring match.** Because `--enable-tool` matches any substring of a tool name, a single `--enable-tool=label` turns on *every* label tool — including the default-disabled `create_label`, `delete_label`, and `set_label_options`. Use a specific pattern like `--enable-tool=create_label` to enable just one.
 
-**Dynamic visibility.** Label tools appear in `tools/list` only when the Label plugin is enabled on the daemon. The server subscribes to Deluge's `PluginEnabledEvent` / `PluginDisabledEvent` push events (the same mechanism the GTK and Web UIs use) — toggling the plugin in any Deluge client propagates to connected MCP peers within seconds via `notifications/tools/list_changed`. No MCP server restart is needed. `--enable-tool` cannot make a label tool visible if the plugin is inactive on the daemon.
+**Dynamic visibility.** Label tools show up in the client's tool list only while the Label plugin is enabled on the daemon. The server subscribes to Deluge's `PluginEnabledEvent` / `PluginDisabledEvent` push events (the same mechanism the GTK and Web UIs use), so toggling the plugin from any Deluge client propagates to connected MCP peers within seconds via a `notifications/tools/list_changed` notification — no restart required. `--enable-tool` cannot make a label tool visible if the plugin is inactive on the daemon.
 
-## HTTP Transport
+### Response shaping
 
-To use the HTTP/SSE transport for remote or agentic clients, start with `--transport http`:
+A client can declare what kind of consumer it is — a token-sensitive LLM, or a byte/parse-sensitive program — and receive JSON shaped to match. The default is **minified** JSON, because the common consumer is a token-sensitive LLM; pass `shape=pretty` when you want human-readable output.
+
+**Quick start** — human-readable output for debugging, on either transport:
+
+```bash
+# stdio: fixed for the life of the process
+deluge-torrent-mcp --response-config 'json?shape=pretty'
+
+# HTTP: chosen per request via the URL path + query
+POST /mcp/json?shape=pretty
+```
+
+It's one DSL — `<format>?<params>` — used in both places. Plain `/mcp`, `/mcp/json` with no params, and stdio with no flag all produce minified output.
+
+`json`-format parameters (v1):
+
+| Param | Values | Default | Effect |
+|---|---|---|---|
+| `shape` | `pretty`, `minified`, `sparse` (comma-separated; `pretty`/`minified` are mutually exclusive) | `minified` | Whitespace and redundancy. `sparse` emits a one-time `defaults` block and omits default-valued fields from `list_torrents`-shaped output — reconstruct a row as `{...defaults, ...row}`. |
+| `ids` | `full` | `full` | How torrent ids are rendered. v1 ships `full` only (the id is the 40/64-character info hash). |
+
+Notes:
+
+- `sparse` only reshapes the `{"torrents": {...}}` envelope (`list_torrents` and the `deluge://torrents` resource); it's a structural no-op on single-torrent output. `minified`/`pretty` apply everywhere.
+- An unknown format or invalid parameter is a hard error: `400 Bad Request` on HTTP, non-zero exit at stdio startup.
+- `--test-connection` honors the shaping flag, so you can run it once to *see* the shape before wiring up a client.
+
+> **Rule of thumb:** the default `minified` (add `sparse` for `list_torrents`-heavy use) keeps token use low for LLM clients. Pass `shape=pretty` when you're reading the output yourself.
+
+### TLS certificate handling
+
+Deluge daemons generate a unique self-signed certificate by default.
+
+- **Default behavior** — certificate verification is skipped, so the server connects out of the box. On each connection it logs a `WARN` to stderr containing the certificate's SHA-256 fingerprint **and the ready-to-paste `--cert-fingerprint` flag**. A `--test-connection` run logs the same line, so it's the easiest way to grab the value.
+- **Secure pinning** — copy that fingerprint into `--cert-fingerprint`. The server then rejects any certificate that doesn't match:
+
+```bash
+deluge-torrent-mcp --cert-fingerprint "A1:B2:C3:..."
+```
+
+---
+
+## Client Setup
+
+### Claude Desktop (stdio)
+
+Add the server to your `claude_desktop_config.json`:
+
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Use the absolute path to the compiled binary and your Deluge RPC credentials:
+
+```json
+{
+  "mcpServers": {
+    "deluge": {
+      "command": "/absolute/path/to/target/release/deluge-torrent-mcp",
+      "args": [
+        "--host", "127.0.0.1",
+        "--port", "58846"
+      ],
+      "env": {
+        "DELUGE_USERNAME": "localclient",
+        "DELUGE_PASSWORD": "your_rpc_password"
+      }
+    }
+  }
+}
+```
+
+> Restart Claude Desktop after editing this file.
+
+### Remote / HTTP clients
+
+Start the server with the HTTP transport, then point clients at `http://<host>:8080/mcp`:
 
 ```bash
 deluge-torrent-mcp -u admin -p secret --transport http --http-bind 0.0.0.0:8080 --api-token "your-secret-token"
 ```
 
-MCP clients connect to `http://<host>:8080/mcp`. The `--api-token` flag is strongly recommended when binding to a network interface — without it, anyone who can reach the port can access the MCP endpoint and control Deluge.
+> The default `--http-bind` is `127.0.0.1:8080` (loopback only). Pass `0.0.0.0:8080` to listen on all interfaces, as above.
 
-Clients must include the token in every request when --api-token is set:
+Choose an authentication mode:
+
+**Shared token — simple, recommended.** Set `--api-token` (or `DELUGE_API_TOKEN`). Every request must carry the token:
 
 ```
 Authorization: Bearer your-secret-token
 ```
 
-> For internet-facing deployments, put this behind a reverse proxy (nginx, Caddy, Traefik) that terminates TLS. The server itself does not handle HTTPS.
+> **Always set a token when binding to a network interface.** Without one, anyone who can reach the port can control Deluge.
 
-## TLS Certificate Handling
-
-Deluge daemons generate unique self-signed certificates by default.
-
-- **Default behavior**: Certificate verification is skipped. A `WARN` is logged to stderr with the certificate's SHA-256 fingerprint and the exact CLI flag to pin it.
-- **Secure pinning**: Copy the fingerprint from the logs and pass it via `--cert-fingerprint`. The server will subsequently reject any certificate that doesn't match:
+**OAuth 2.1 — for internet-facing access.** When remote clients connect back to your MCP server over the internet, set `--oauth-issuer` to the **public HTTPS URL** clients reach (e.g. `https://mcp.dyn.dns`, not a localhost URL) to enable the embedded OAuth 2.1 authorization server (authorization-code flow with PKCE, dynamic client registration, an admin-gated consent screen, and refresh-token rotation):
 
 ```bash
-deluge-torrent-mcp -u admin -p secret --cert-fingerprint "A1:B2:C3..."
+deluge-torrent-mcp -u admin -p secret --transport http \
+  --oauth-issuer https://mcp.dyn.dns \
+  --api-token "your-access-code" \
+  --oauth-state-file /home/youruser/.local/share/deluge-mcp/oauth-state.json
 ```
+
+> **Set `--api-token` alongside `--oauth-issuer`.** The consent screen is gated by the `--api-token` value — it's the "Access Code" an operator must enter to approve a client registration. Without `--api-token`, the consent screen has no password and **anyone who can reach it can click through and obtain a token**. With it set, OAuth gives each client its own revocable credential *and* the token gates who may authorize new clients. The same token also keeps working as a static bearer-token fallback.
+
+- Discovery metadata is published at `<issuer>/.well-known/oauth-authorization-server`; conforming clients register and obtain tokens automatically (subject to the consent gate above).
+- By default OAuth state is in-memory, so every client must re-register after a restart. Pass `--oauth-state-file <PATH>` to persist client registrations and tokens across restarts. Writes are atomic; on Unix the file is `chmod`'d to `0600` because it holds bearer tokens — on Windows, place it inside a user-only directory.
+
+**Behind a reverse proxy / TLS.** The server speaks plain HTTP only — terminate TLS at a reverse proxy (nginx, Caddy, Traefik). When the proxy forwards a public hostname, add it with `--allowed-host` (or `DELUGE_ALLOWED_HOST`), otherwise the built-in DNS-rebinding guard rejects the request with `403`. The loopback hosts, the `--http-bind` host, and the `--oauth-issuer` host are accepted automatically.
+
+---
+
+## CLI reference
+
+```bash
+deluge-torrent-mcp --host 192.168.1.50 --port 58846 -u admin -p secret [OPTIONS]
+```
+
+| Flag | Env variable | Default | Description |
+|---|---|---|---|
+| `--host <HOST>` | `DELUGE_HOST` | `127.0.0.1` | Deluge daemon hostname or IP (IPv6: bare address, e.g. `::1`) |
+| `--port <PORT>` | `DELUGE_PORT` | `58846` | Deluge RPC port |
+| `-u, --username <USER>` | `DELUGE_USERNAME` | — | Deluge RPC username |
+| `-p, --password <PASS>` | `DELUGE_PASSWORD` | — | Deluge RPC password |
+| `--cert-fingerprint <SHA256>` | — | — | Pin the daemon's TLS certificate by fingerprint. A successful `--test-connection` (or any connection) logs the exact value to paste here. |
+| `--enable-tool <PATTERN>` | — | — | Enable tools matching pattern (min 3 chars, substring match). Repeatable, comma-separated |
+| `--disable-tool <PATTERN>` | — | — | Disable tools matching pattern. Flags are processed in order; last wins |
+| `--list-tools` | — | off | Print all tools with their default enabled/disabled state and exit (no daemon connection needed) |
+| `--transport <stdio\|http>` | — | `stdio` | MCP transport to use |
+| `--http-bind <ADDR>` | — | `127.0.0.1:8080` | Bind address for the HTTP transport. Use `0.0.0.0:8080` for all interfaces (IPv6: bracket notation, e.g. `[::]:8080`) |
+| `--allowed-host <HOST>` | `DELUGE_ALLOWED_HOST` | — | Extra Host header value(s) to accept on the HTTP transport, for when behind a reverse proxy. Repeatable, comma-separated |
+| `--api-token <TOKEN>` | `DELUGE_API_TOKEN` | — | Bearer token required for HTTP requests (recommended). In OAuth mode it also gates the consent screen as the operator Access Code |
+| `--oauth-issuer <URL>` | `DELUGE_OAUTH_ISSUER` | — | Public HTTPS base URL clients reach over the internet; setting it enables OAuth 2.1 mode |
+| `--oauth-state-file <PATH>` | `DELUGE_OAUTH_STATE_FILE` | — | Persist OAuth client registrations and tokens across restarts (only meaningful with `--oauth-issuer`) |
+| `--response-config <FORMAT?PARAMS>` | `DELUGE_RESPONSE_CONFIG` | `minified` | Shape stdio JSON output, e.g. `json?shape=pretty` for human-readable output |
+| `--test-connection` | — | off | Connect to Deluge, verify connection, cert fingerprint, response config, and exit |
+
+---
 
 ## Development & Testing
 
-When developing or modifying this MCP server, do not test against your primary Deluge instance to avoid accidental data loss.
-
-Instead, spin up a disposable Deluge daemon using Docker:
+When developing or modifying this server, do not test against your primary Deluge instance — you risk accidental data loss. Spin up a disposable daemon with Docker instead:
 
 ```yaml
 # docker-compose.yml
@@ -191,14 +301,14 @@ services:
     restart: unless-stopped
 ```
 
-Run `docker-compose up -d`, check `./test-config/auth` for the generated credentials, and point the MCP server to `127.0.0.1:58846`.
+Run `docker-compose up -d`, read the generated credentials from `./test-config/auth`, and point the server at `127.0.0.1:58846`.
 
-## Note on Logging
+Contributor notes (architecture, the in-tree Deluge RPC implementation, the stdout/JSON-RPC framing constraint, and more) live in [`CLAUDE.md`](CLAUDE.md) and the ADRs under [`docs/adr/`](docs/adr/).
 
-All tracing logs are directed to stderr. Do not print to stdout (`println!`), as MCP uses stdout for JSON-RPC framing. Any stray standard output will break the connection with the MCP client.
+---
 
 ## License
 
 Copyright (c) 2026 Sandy McArthur, Jr.
 
-This project is licensed under the [MIT License](LICENSE). Third-party dependency licenses are listed in [THIRD_PARTY_LICENSES.html](THIRD_PARTY_LICENSES.html).
+This project is licensed under the [MIT License](LICENSE). Third-party dependency licenses are listed in [THIRD_PARTY_LICENSES.html](https://htmlpreview.github.io/?https://github.com/sandymac/deluge-torrent-mcp/blob/main/THIRD_PARTY_LICENSES.html).

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ It's one DSL — `<format>?<params>` — used in both places. Plain `/mcp`, `/mc
 
 Notes:
 
-- `defaults` only reshapes the `{"torrents": {...}}` envelope (`list_torrents` and the `deluge://torrents` resource); it's a structural no-op on single-torrent output. `minified`/`pretty` apply everywhere.
+- `defaults` applies to large, repetitive payloads (such as `list_torrents`) and is a no-op elsewhere; `minified`/`pretty` apply everywhere. Which payloads it covers may expand over time.
 - An unknown format or invalid parameter is a hard error: `400 Bad Request` on HTTP, non-zero exit at stdio startup.
 - `--test-connection` honors the shaping flag, so you can run it once to *see* the shape before wiring up a client.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Key properties:
 
 - **Safety gates** — tools that can delete data or rewrite paths are **disabled by default** and must be turned on individually, so a hallucinating model can't wreck your library.
 - **Two transports** — **stdio** for a local client like Claude Desktop, and **HTTP/SSE** for a network-accessible, always-on server with optional token or OAuth 2.1 authentication.
-- **Configurable response shaping** — per-client JSON formatting (minified and/or sparse to balance token count vs reasoning abilities) on both transports, with more encodings planned.
+- **Configurable response shaping** — per-client JSON formatting (minified and/or defaults-factoring to balance token count vs reasoning abilities) on both transports, with more encodings planned.
 - **Flexible TLS** — works out of the box with Deluge's default self-signed certificate, log lines provide an easy copy-paste pinning mechanism for pinning to a cert.
 - **Native RPC** — speaks Deluge's binary protocol (rencode/zlib over TLS) directly, deluged thinks it's another client.
 
@@ -43,7 +43,7 @@ cargo build --release
 
 The compiled binary lands at `target/release/deluge-torrent-mcp`.
 
-Sanity-check the build without touching a daemon — `--list-tools` prints the tool inventory and exits before connecting:
+Sanity-check the build without touching a daemon via `--help` or `--list-tools`:
 
 ```bash
 ./target/release/deluge-torrent-mcp --list-tools
@@ -118,9 +118,9 @@ deluge-torrent-mcp --enable-tools=move_storage,rename_folder,rename_files,force_
 
 When the AI calls a disabled tool, the server returns an error naming the exact flag needed to enable it.
 
-### Label plugin
+### Labels
 
-Deluge ships a built-in **Label** plugin for grouping and bulk-operating on torrents. When it's enabled on the daemon, the server exposes eight label-aware tools:
+Deluge ships a built-in **Label** plugin, disabled by default, for grouping and bulk-operating on torrents. When it's enabled on the daemon, the server exposes eight label-aware tools:
 
 | Tool | Default |
 |---|---|
@@ -159,16 +159,16 @@ It's one DSL — `<format>?<params>` — used in both places. Plain `/mcp`, `/mc
 
 | Param | Values | Default | Effect |
 |---|---|---|---|
-| `shape` | `pretty`, `minified`, `sparse` (comma-separated; `pretty`/`minified` are mutually exclusive) | `minified` | Whitespace and redundancy. `sparse` emits a one-time `defaults` block and omits default-valued fields from `list_torrents`-shaped output — reconstruct a row as `{...defaults, ...row}`. |
+| `shape` | `pretty`, `minified`, `defaults` (comma-separated; `pretty`/`minified` are mutually exclusive) | `minified` | Whitespace and redundancy. `defaults` emits a one-time `defaults` block and omits default-valued fields from `list_torrents`-shaped output — reconstruct a row as `{...defaults, ...row}`. |
 | `ids` | `full` | `full` | How torrent ids are rendered. v1 ships `full` only (the id is the 40/64-character info hash). |
 
 Notes:
 
-- `sparse` only reshapes the `{"torrents": {...}}` envelope (`list_torrents` and the `deluge://torrents` resource); it's a structural no-op on single-torrent output. `minified`/`pretty` apply everywhere.
+- `defaults` only reshapes the `{"torrents": {...}}` envelope (`list_torrents` and the `deluge://torrents` resource); it's a structural no-op on single-torrent output. `minified`/`pretty` apply everywhere.
 - An unknown format or invalid parameter is a hard error: `400 Bad Request` on HTTP, non-zero exit at stdio startup.
 - `--test-connection` honors the shaping flag, so you can run it once to *see* the shape before wiring up a client.
 
-> **Rule of thumb:** the default `minified` (add `sparse` for `list_torrents`-heavy use) keeps token use low for LLM clients. Pass `shape=pretty` when you're reading the output yourself.
+> **Rule of thumb:** the default `minified` (add `defaults` for `list_torrents`-heavy use) keeps token use low for LLM clients. Pass `shape=pretty` when you're reading the output yourself.
 
 ### TLS certificate handling
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The MCP server authenticates to Deluge with an RPC username and password. On the
 
 Supply them by flag (`-u`/`-p`) or, preferably, by environment variable (`DELUGE_USERNAME` / `DELUGE_PASSWORD`):
 
-> **Prefer environment variables for credentials.** Passwords passed as CLI flags show up in process listings (`ps`); environment variables don't.
+> **Prefer environment variables for credentials.** Passwords passed as CLI flags appear in shell history and in process listings (`ps`). Environment variables avoid both, though they're still sensitive — a process's environment is readable by the same user (and root) via `/proc/<pid>/environ`.
 
 ### Safety gates
 
@@ -274,7 +274,7 @@ deluge-torrent-mcp --host 192.168.1.50 --port 58846 -u admin -p secret [OPTIONS]
 | `--api-token <TOKEN>` | `DELUGE_API_TOKEN` | — | Bearer token required for HTTP requests (recommended). In OAuth mode it also gates the consent screen as the operator Access Code |
 | `--oauth-issuer <URL>` | `DELUGE_OAUTH_ISSUER` | — | Public HTTPS base URL clients reach over the internet; setting it enables OAuth 2.1 mode |
 | `--oauth-state-file <PATH>` | `DELUGE_OAUTH_STATE_FILE` | — | Persist OAuth client registrations and tokens across restarts (only meaningful with `--oauth-issuer`) |
-| `--response-config <FORMAT?PARAMS>` | `DELUGE_RESPONSE_CONFIG` | `minified` | Shape stdio JSON output, e.g. `json?shape=pretty` for human-readable output |
+| `--response-config <FORMAT?PARAMS>` | `DELUGE_RESPONSE_CONFIG` | — | Shape stdio JSON output. Omit for minified; pass `json?shape=pretty` for human-readable output |
 | `--test-connection` | — | off | Connect to Deluge, verify connection, cert fingerprint, response config, and exit |
 
 ---

--- a/THIRD_PARTY_LICENSES.html
+++ b/THIRD_PARTY_LICENSES.html
@@ -4265,7 +4265,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/deluge-torrent-mcp ">deluge-torrent-mcp 0.9.0</a></li>
+                    <li><a href=" https://crates.io/crates/deluge-torrent-mcp ">deluge-torrent-mcp 0.9.1</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 

--- a/docs/adr/0012-resolve-response-shaping-config-per-request-not-per-session.md
+++ b/docs/adr/0012-resolve-response-shaping-config-per-request-not-per-session.md
@@ -55,14 +55,16 @@ Resolve the `ResponseConfig` **per request**, not per session:
 - The default config makes `shape()` call `to_string_pretty` verbatim, so existing
   clients that opt into nothing see byte-identical output (with one deliberate
   consistency fix: a few read paths that previously emitted minified now default to
-  pretty like every other tool).
+  pretty like every other tool). *(Superseded — see the Update below: the default is now
+  minified.)*
 - Shaping applies to all JSON the server emits: tool outputs, MCP resource reads (which
   reach the same per-request config via their `RequestContext`), and the `--test-connection`
   diagnostic (which uses the parsed `--response-config` directly, so it also demonstrates the
   switch is in effect). The `deluge://torrents` resource is wrapped in the `{"torrents": {...}}`
   envelope so `sparse` applies to it as it does to `list_torrents`; `sparse` is a structural
   no-op on the single-torrent resource and the diagnostic (not that envelope), where
-  `minified`/`pretty` still apply.
+  `minified`/`pretty` still apply. *(The `sparse` token was renamed `defaults` — see the
+  Update below.)*
 
 ## Update (2026-06-02)
 

--- a/docs/adr/0012-resolve-response-shaping-config-per-request-not-per-session.md
+++ b/docs/adr/0012-resolve-response-shaping-config-per-request-not-per-session.md
@@ -63,3 +63,12 @@ Resolve the `ResponseConfig` **per request**, not per session:
   envelope so `sparse` applies to it as it does to `list_torrents`; `sparse` is a structural
   no-op on the single-torrent resource and the diagnostic (not that envelope), where
   `minified`/`pretty` still apply.
+
+## Update (2026-06-02)
+
+The default shape was changed from `pretty` to `minified` after testing: in practice
+the common consumer is a token-sensitive LLM, so the byte-for-byte back-compat default
+described above cost tokens on every call for the typical client. The default now
+serializes with `to_string` (minified); human-readable output is opt-in via `shape=pretty`.
+This supersedes the "byte-identical to `to_string_pretty`" consequence above — that
+guarantee now holds only when a client explicitly requests `shape=pretty`.

--- a/docs/adr/0012-resolve-response-shaping-config-per-request-not-per-session.md
+++ b/docs/adr/0012-resolve-response-shaping-config-per-request-not-per-session.md
@@ -72,3 +72,9 @@ described above cost tokens on every call for the typical client. The default no
 serializes with `to_string` (minified); human-readable output is opt-in via `shape=pretty`.
 This supersedes the "byte-identical to `to_string_pretty`" consequence above — that
 guarantee now holds only when a client explicitly requests `shape=pretty`.
+
+The redundancy-omission shape token was also renamed `sparse` → `defaults`: it factors out
+shared *default-valued* fields into a `defaults` block (not empty/null fields, which `sparse`
+would imply), so the token now matches both the emitted block and the `{...defaults, ...row}`
+reconstruction. Internally the flag is `ShapeOpts::omit_defaults` and the transform is
+`factor_defaults`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,7 @@ struct Cli {
     /// Shape STDIO tool responses for a token-sensitive (LLM) or byte-sensitive (programmatic)
     /// consumer. Format `<format>?<params>`, mirroring the HTTP `/mcp/<format>?<params>` URL.
     /// Example: --response-config 'json?shape=pretty'.
-    /// v1 values: shape=pretty|minified|sparse (CSV; pretty/minified are exclusive), ids=full.
+    /// v1 values: shape=pretty|minified|defaults (CSV; pretty/minified are exclusive), ids=full.
     /// Omit for the default (minified); pass shape=pretty for human-readable output.
     /// On the HTTP transport this is chosen per-request via the URL instead of this flag.
     #[arg(long, env = "DELUGE_RESPONSE_CONFIG", value_name = "FORMAT?PARAMS")]
@@ -628,10 +628,10 @@ mod tests {
     }
 
     #[test]
-    fn request_config_sparse_query() {
-        let cfg = parse_request_config("/mcp/json", "shape=minified,sparse").unwrap();
+    fn request_config_defaults_query() {
+        let cfg = parse_request_config("/mcp/json", "shape=minified,defaults").unwrap();
         assert_eq!(cfg.shape.whitespace, Whitespace::Minified);
-        assert!(cfg.shape.sparse);
+        assert!(cfg.shape.omit_defaults);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -689,10 +689,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bare_mcp_path_yields_default_pretty() {
+    async fn bare_mcp_path_yields_default_minified() {
         let (status, body) = send("/mcp").await;
         assert_eq!(status, axum::http::StatusCode::OK);
-        assert!(body.contains("minified=false"), "body: {body}");
+        assert!(body.contains("minified=true"), "body: {body}");
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,20 +94,25 @@ struct Cli {
 
     /// Additional Host header value(s) to accept on the HTTP transport, for when the
     /// server runs behind a reverse proxy that forwards a public hostname (e.g.
-    /// mcp.example.com). The loopback hosts, the --http-bind host, and the --oauth-issuer
+    /// mcp.dyn.dns). The loopback hosts, the --http-bind host, and the --oauth-issuer
     /// host are always accepted; use this for any other public name. Comma-separated or
     /// repeated. Without it, rmcp's DNS-rebinding guard rejects proxied requests with 403.
     #[arg(long = "allowed-host", value_name = "HOST", value_delimiter = ',', action = clap::ArgAction::Append, env = "DELUGE_ALLOWED_HOST")]
     allowed_host: Vec<String>,
 
-    /// Bearer token required for HTTP transport requests (recommended)
+    /// Bearer token required for HTTP transport requests (recommended). In OAuth mode this
+    /// value also gates the consent screen as the operator "Access Code" — set it, or anyone
+    /// who reaches the consent page can approve a client and obtain a token.
     #[arg(long, env = "DELUGE_API_TOKEN")]
     api_token: Option<String>,
 
-    /// Base URL of this server as the OAuth 2.1 issuer (enables OAuth mode).
-    /// Example: <http://localhost:8080>  or  <https://mcp.example.com>
-    /// When set, OAuth 2.1 endpoints are activated and MCP requests require OAuth tokens.
-    /// Can be combined with --api-token to also accept static tokens as a fallback.
+    /// Base URL of this server as the OAuth 2.1 issuer (enables OAuth mode). Intended for
+    /// internet-facing deployments where remote clients connect back to your MCP server;
+    /// use the public HTTPS URL clients reach, e.g. <https://mcp.dyn.dns> (not a
+    /// localhost URL). When set, OAuth 2.1 endpoints are activated and MCP requests require
+    /// OAuth tokens. Set --api-token alongside it: that value gates the consent screen (the
+    /// operator Access Code) and also works as a static bearer-token fallback. Without it the
+    /// consent screen is ungated and anyone who can reach it can authorize a client.
     #[arg(long, env = "DELUGE_OAUTH_ISSUER")]
     oauth_issuer: Option<String>,
 
@@ -118,16 +123,18 @@ struct Cli {
     #[arg(long, env = "DELUGE_OAUTH_STATE_FILE", value_name = "PATH")]
     oauth_state_file: Option<std::path::PathBuf>,
 
-    /// Connect to Deluge, print session status, and exit
-    #[arg(long, default_value_t = false)]
-    test_connection: bool,
-
     /// Shape STDIO tool responses for a token-sensitive (LLM) or byte-sensitive (programmatic)
-    /// consumer. Format `<format>?<params>`, mirroring the HTTP `/mcp/<format>?<params>` path.
-    /// v1: `json?shape=minified`, `json?shape=minified,sparse`, `json?shape=sparse`. Omit for
-    /// today's pretty output. (HTTP transport sets this per-request via the URL instead.)
+    /// consumer. Format `<format>?<params>`, mirroring the HTTP `/mcp/<format>?<params>` URL.
+    /// Example: --response-config 'json?shape=pretty'.
+    /// v1 values: shape=pretty|minified|sparse (CSV; pretty/minified are exclusive), ids=full.
+    /// Omit for the default (minified); pass shape=pretty for human-readable output.
+    /// On the HTTP transport this is chosen per-request via the URL instead of this flag.
     #[arg(long, env = "DELUGE_RESPONSE_CONFIG", value_name = "FORMAT?PARAMS")]
     response_config: Option<String>,
+
+    /// Connect to Deluge, verify connection, cert fingerprint, response config, and exit
+    #[arg(long, default_value_t = false)]
+    test_connection: bool,
 }
 
 #[derive(Debug, Clone, clap::ValueEnum)]

--- a/src/response_config/mod.rs
+++ b/src/response_config/mod.rs
@@ -11,8 +11,8 @@
 //!
 //! The path segment names the *payload format* (the encoding namespace — `json` in v1,
 //! reserving `toon`/`xml`/`text` for later); the query string carries parameters scoped to
-//! that format. All token-saving shaping is strictly opt-in: the [`Default`] is `json` +
-//! `pretty` + `full`, byte-for-byte today's behavior.
+//! that format. The [`Default`] is `json` + `minified` + `full`: compact output suits the
+//! LLM clients that are the common consumer. Human-readable output is opt-in via `shape=pretty`.
 
 mod shape;
 
@@ -49,9 +49,9 @@ pub(crate) struct ShapeOpts {
 /// Whitespace rendering for the `json` format.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum Whitespace {
-    /// `serde_json::to_string_pretty` — today's behavior, the default.
+    /// `serde_json::to_string_pretty` — human-readable; opt in with `shape=pretty`.
     Pretty,
-    /// `serde_json::to_string` — no whitespace.
+    /// `serde_json::to_string` — no whitespace. The default.
     Minified,
 }
 
@@ -63,12 +63,13 @@ pub(crate) enum IdSelector {
 }
 
 impl Default for ResponseConfig {
-    /// `json` + `pretty` + `full` — byte-for-byte today's behavior. All shaping is opt-in.
+    /// `json` + `minified` + `full`. Compact output is the default because LLM clients are the
+    /// common consumer; opt into human-readable output with `shape=pretty`.
     fn default() -> Self {
         Self {
             format: Format::Json,
             shape: ShapeOpts {
-                whitespace: Whitespace::Pretty,
+                whitespace: Whitespace::Minified,
                 sparse: false,
             },
             ids: IdSelector::Full,
@@ -215,10 +216,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_is_json_pretty_full() {
+    fn default_is_json_minified_full() {
         let cfg = ResponseConfig::default();
         assert_eq!(cfg.format, Format::Json);
-        assert_eq!(cfg.shape.whitespace, Whitespace::Pretty);
+        assert_eq!(cfg.shape.whitespace, Whitespace::Minified);
         assert!(!cfg.shape.sparse);
         assert_eq!(cfg.ids, IdSelector::Full);
     }
@@ -253,9 +254,10 @@ mod tests {
     }
 
     #[test]
-    fn parses_sparse_with_implicit_pretty() {
+    fn parses_sparse_with_implicit_minified() {
+        // `sparse` alone leaves whitespace at the default (minified).
         let cfg = parse("json", "shape=sparse").unwrap();
-        assert_eq!(cfg.shape.whitespace, Whitespace::Pretty);
+        assert_eq!(cfg.shape.whitespace, Whitespace::Minified);
         assert!(cfg.shape.sparse);
     }
 

--- a/src/response_config/mod.rs
+++ b/src/response_config/mod.rs
@@ -42,8 +42,9 @@ pub(crate) enum Format {
 pub(crate) struct ShapeOpts {
     /// Whitespace rendering.
     pub(crate) whitespace: Whitespace,
-    /// When true, emit a one-time `defaults` block and omit per-row default-valued fields.
-    pub(crate) sparse: bool,
+    /// When true, emit a one-time `defaults` block and omit per-row default-valued fields
+    /// (the `defaults` shape token).
+    pub(crate) omit_defaults: bool,
 }
 
 /// Whitespace rendering for the `json` format.
@@ -70,7 +71,7 @@ impl Default for ResponseConfig {
             format: Format::Json,
             shape: ShapeOpts {
                 whitespace: Whitespace::Minified,
-                sparse: false,
+                omit_defaults: false,
             },
             ids: IdSelector::Full,
         }
@@ -106,7 +107,7 @@ impl std::fmt::Display for ConfigParseError {
             Self::InvalidValue { param, value } => match param.as_str() {
                 "shape" => write!(
                     f,
-                    "invalid shape value '{value}' (valid: pretty, minified, sparse)"
+                    "invalid shape value '{value}' (valid: pretty, minified, defaults)"
                 ),
                 "ids" => write!(f, "invalid ids value '{value}' (valid: full)"),
                 other => write!(f, "invalid value '{value}' for parameter '{other}'"),
@@ -164,7 +165,7 @@ pub(crate) fn parse(format_segment: &str, query: &str) -> Result<ResponseConfig,
     Ok(cfg)
 }
 
-/// Apply a `shape=` CSV value (e.g. `minified,sparse`) onto [`ShapeOpts`].
+/// Apply a `shape=` CSV value (e.g. `minified,defaults`) onto [`ShapeOpts`].
 fn parse_shape(value: &str, shape: &mut ShapeOpts) -> Result<(), ConfigParseError> {
     // An empty value (`?shape=` or a bare `?shape`) is a hard error, not a silent no-op —
     // otherwise a typo that drops the value masquerades as a working config.
@@ -188,7 +189,7 @@ fn parse_shape(value: &str, shape: &mut ShapeOpts) -> Result<(), ConfigParseErro
                 saw_minified = true;
                 shape.whitespace = Whitespace::Minified;
             }
-            "sparse" => shape.sparse = true,
+            "defaults" => shape.omit_defaults = true,
             other => {
                 return Err(ConfigParseError::InvalidValue {
                     param: "shape".to_string(),
@@ -204,7 +205,7 @@ fn parse_shape(value: &str, shape: &mut ShapeOpts) -> Result<(), ConfigParseErro
 }
 
 /// Parse a STDIO `--response-config` string of the form `<format>?<params>` (e.g.
-/// `json?shape=minified,sparse`). Splits on the first `?` and delegates to [`parse`], so the
+/// `json?shape=minified,defaults`). Splits on the first `?` and delegates to [`parse`], so the
 /// STDIO flag and the HTTP path+query share one grammar.
 pub(crate) fn parse_flag(s: &str) -> Result<ResponseConfig, ConfigParseError> {
     let (format, query) = s.split_once('?').unwrap_or((s, ""));
@@ -220,7 +221,7 @@ mod tests {
         let cfg = ResponseConfig::default();
         assert_eq!(cfg.format, Format::Json);
         assert_eq!(cfg.shape.whitespace, Whitespace::Minified);
-        assert!(!cfg.shape.sparse);
+        assert!(!cfg.shape.omit_defaults);
         assert_eq!(cfg.ids, IdSelector::Full);
     }
 
@@ -243,22 +244,22 @@ mod tests {
     fn parses_minified() {
         let cfg = parse("json", "shape=minified").unwrap();
         assert_eq!(cfg.shape.whitespace, Whitespace::Minified);
-        assert!(!cfg.shape.sparse);
+        assert!(!cfg.shape.omit_defaults);
     }
 
     #[test]
-    fn parses_minified_and_sparse_csv() {
-        let cfg = parse("json", "shape=minified,sparse").unwrap();
+    fn parses_minified_and_defaults_csv() {
+        let cfg = parse("json", "shape=minified,defaults").unwrap();
         assert_eq!(cfg.shape.whitespace, Whitespace::Minified);
-        assert!(cfg.shape.sparse);
+        assert!(cfg.shape.omit_defaults);
     }
 
     #[test]
-    fn parses_sparse_with_implicit_minified() {
-        // `sparse` alone leaves whitespace at the default (minified).
-        let cfg = parse("json", "shape=sparse").unwrap();
+    fn parses_defaults_with_implicit_minified() {
+        // `defaults` alone leaves whitespace at the default (minified).
+        let cfg = parse("json", "shape=defaults").unwrap();
         assert_eq!(cfg.shape.whitespace, Whitespace::Minified);
-        assert!(cfg.shape.sparse);
+        assert!(cfg.shape.omit_defaults);
     }
 
     #[test]
@@ -268,9 +269,9 @@ mod tests {
 
     #[test]
     fn parses_multiple_params() {
-        let cfg = parse("json", "shape=minified,sparse&ids=full").unwrap();
+        let cfg = parse("json", "shape=minified,defaults&ids=full").unwrap();
         assert_eq!(cfg.shape.whitespace, Whitespace::Minified);
-        assert!(cfg.shape.sparse);
+        assert!(cfg.shape.omit_defaults);
         assert_eq!(cfg.ids, IdSelector::Full);
     }
 
@@ -343,7 +344,7 @@ mod tests {
         assert!(parse("json", "shape=x")
             .unwrap_err()
             .to_string()
-            .contains("pretty, minified, sparse"));
+            .contains("pretty, minified, defaults"));
     }
 
     // --- parser: HTTP-form and STDIO-form equivalence (single-grammar guarantee) ---
@@ -352,8 +353,8 @@ mod tests {
     fn http_form_equals_stdio_form() {
         // HTTP supplies (segment, query) separately; STDIO supplies one "<format>?<params>"
         // string. The same logical config must parse identically.
-        let http = parse("json", "shape=minified,sparse&ids=full").unwrap();
-        let stdio = parse_flag("json?shape=minified,sparse&ids=full").unwrap();
+        let http = parse("json", "shape=minified,defaults&ids=full").unwrap();
+        let stdio = parse_flag("json?shape=minified,defaults&ids=full").unwrap();
         assert_eq!(http, stdio);
     }
 

--- a/src/response_config/shape.rs
+++ b/src/response_config/shape.rs
@@ -3,8 +3,8 @@
 
 //! The pure JSON shaping transform. Given a tool's output [`Value`](serde_json::Value) and a
 //! [`ResponseConfig`], produce the serialized string the consumer asked for — minified or
-//! pretty whitespace, optionally sparse (a one-time `defaults` block with per-row default
-//! fields omitted). No I/O; fully unit-testable.
+//! pretty whitespace, optionally factoring out defaults (the `defaults` shape token: a one-time
+//! `defaults` block with per-row default-valued fields omitted). No I/O; fully unit-testable.
 
 use serde_json::{Map, Value};
 
@@ -15,7 +15,7 @@ use super::{ResponseConfig, Whitespace};
 /// `const`-compatible `Value`.
 type DefaultEntry = (&'static str, fn() -> Value);
 
-/// The v1 sparse default set for torrent rows, from the measured distribution in issue #9.
+/// The v1 default set for torrent rows, from the measured distribution in issue #9.
 /// A field is omitted from a row only when (a) every row carries it and (b) its value equals
 /// the default here, so the consumer reconstructs a row as `{...defaults, ...row}` losslessly.
 const TORRENT_DEFAULTS: &[DefaultEntry] = &[
@@ -29,8 +29,8 @@ const TORRENT_DEFAULTS: &[DefaultEntry] = &[
 
 /// Shape a tool's JSON output for the declared consumer. Pure transform; never touches I/O.
 pub(crate) fn shape_response(value: Value, cfg: &ResponseConfig) -> String {
-    let value = if cfg.shape.sparse {
-        sparsify(value)
+    let value = if cfg.shape.omit_defaults {
+        factor_defaults(value)
     } else {
         value
     };
@@ -41,13 +41,13 @@ pub(crate) fn shape_response(value: Value, cfg: &ResponseConfig) -> String {
     serialized.unwrap_or_default()
 }
 
-/// Apply the sparse transform: emit a sibling `defaults` block and omit per-row default-valued
+/// Apply the `defaults` transform: emit a sibling `defaults` block and omit per-row default-valued
 /// fields. Operates only on a `{ "torrents": { <hash>: {fields} }, ... }`-shaped object — i.e.
 /// `list_torrents` output and the `deluge://torrents` resource (which is wrapped in that
 /// envelope). Any other shape passes through unchanged, including the bare `{ <hash>: {fields} }`
-/// map that `get_torrent_status` (batch) and the single-torrent resource emit — sparse only
-/// applies to the explicit `torrents` envelope.
-fn sparsify(value: Value) -> Value {
+/// map that `get_torrent_status` (batch) and the single-torrent resource emit — this transform
+/// only applies to the explicit `torrents` envelope.
+fn factor_defaults(value: Value) -> Value {
     let Value::Object(mut top) = value else {
         return value;
     };
@@ -110,10 +110,10 @@ mod tests {
     use crate::response_config::{IdSelector, Format, ShapeOpts};
     use serde_json::json;
 
-    fn cfg(whitespace: Whitespace, sparse: bool) -> ResponseConfig {
+    fn cfg(whitespace: Whitespace, omit_defaults: bool) -> ResponseConfig {
         ResponseConfig {
             format: Format::Json,
-            shape: ShapeOpts { whitespace, sparse },
+            shape: ShapeOpts { whitespace, omit_defaults },
             ids: IdSelector::Full,
         }
     }
@@ -151,7 +151,7 @@ mod tests {
     }
 
     #[test]
-    fn sparse_emits_defaults_and_omits_defaulted_fields() {
+    fn defaults_emits_defaults_and_omits_defaulted_fields() {
         let got = shape_response(sample(), &cfg(Whitespace::Pretty, true));
         let parsed: Value = serde_json::from_str(&got).unwrap();
 
@@ -175,8 +175,8 @@ mod tests {
     }
 
     #[test]
-    fn sparse_round_trips_to_full_rows() {
-        // Merging defaults into each sparse row must reproduce the original rows exactly.
+    fn defaults_round_trips_to_full_rows() {
+        // Merging defaults into each omitted row must reproduce the original rows exactly.
         let original = sample();
         let shaped: Value =
             serde_json::from_str(&shape_response(original.clone(), &cfg(Whitespace::Minified, true)))
@@ -184,10 +184,10 @@ mod tests {
 
         let defaults = shaped["defaults"].as_object().unwrap();
         for (hash, orig_row) in original["torrents"].as_object().unwrap() {
-            let sparse_row = shaped["torrents"][hash].as_object().unwrap();
-            // row = {...defaults, ...sparse_row}
+            let omitted_row = shaped["torrents"][hash].as_object().unwrap();
+            // row = {...defaults, ...omitted_row}
             let mut merged = defaults.clone();
-            for (k, v) in sparse_row {
+            for (k, v) in omitted_row {
                 merged.insert(k.clone(), v.clone());
             }
             assert_eq!(
@@ -225,7 +225,7 @@ mod tests {
     }
 
     #[test]
-    fn non_torrent_shape_passes_through_under_sparse() {
+    fn non_torrent_shape_passes_through_under_defaults() {
         let scalar = json!({"free_space": 12345});
         let got = shape_response(scalar.clone(), &cfg(Whitespace::Pretty, true));
         assert_eq!(got, serde_json::to_string_pretty(&scalar).unwrap());
@@ -236,7 +236,7 @@ mod tests {
     }
 
     #[test]
-    fn sparse_skips_default_key_absent_from_some_rows() {
+    fn defaults_skips_default_key_absent_from_some_rows() {
         // If a default key isn't present in every row, it must not be declared/omitted —
         // otherwise the merge would add a key a row never had.
         let v = json!({

--- a/src/response_config/shape.rs
+++ b/src/response_config/shape.rs
@@ -198,11 +198,11 @@ mod tests {
         }
     }
 
-    /// T7 lean regression guard: with the default config, every shape a handler actually emits
-    /// must serialize byte-identically to the pre-change `to_string_pretty` call. Covers the
-    /// add_torrent array, the remove/set_label flat object, and the pause/resume_label object.
+    /// Lean regression guard: with the default config (minified), every shape a handler actually
+    /// emits must serialize byte-identically to `serde_json::to_string`. Covers the add_torrent
+    /// array, the remove/set_label flat object, and the pause/resume_label object.
     #[test]
-    fn default_config_is_byte_identical_for_handler_output_shapes() {
+    fn default_config_is_byte_identical_to_minified() {
         let shapes = [
             // add_torrent batch (array of per-source results)
             json!([{"info_hash": "aaaa"}, {"error": "bad source"}]),
@@ -218,8 +218,8 @@ mod tests {
         for v in shapes {
             assert_eq!(
                 shape_response(v.clone(), &default),
-                serde_json::to_string_pretty(&v).unwrap(),
-                "default-config output drifted from to_string_pretty for {v}"
+                serde_json::to_string(&v).unwrap(),
+                "default-config output drifted from to_string (minified) for {v}"
             );
         }
     }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -514,7 +514,7 @@ impl ServerHandler for DelugeServer {
                 .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
 
             // Wrap in the {"torrents": {<hash>: {...}}} envelope so this resource shapes
-            // identically to list_torrents — in particular so `sparse` (which targets that
+            // identically to list_torrents — in particular so `defaults` (which targets that
             // envelope) elides default-valued fields here too, the biggest payload in the
             // system. Resource reads honor the same per-request (HTTP) / --response-config
             // (STDIO) shaping as tool outputs.
@@ -628,13 +628,13 @@ mod tests {
             format: Format::Json,
             shape: ShapeOpts {
                 whitespace: Whitespace::Minified,
-                sparse: true,
+                omit_defaults: true,
             },
             ids: IdSelector::Full,
         };
         // Synthesize the rmcp-injected http::request::Parts carrying the per-request config.
         let mut parts = axum::http::Request::builder()
-            .uri("/mcp/json?shape=minified,sparse")
+            .uri("/mcp/json?shape=minified,defaults")
             .body(())
             .unwrap()
             .into_parts()


### PR DESCRIPTION
@
## Summary

Changes the default response shape, renames a response-shaping DSL token for accuracy, and overhauls the README for operators. Releases as **0.9.1**.

### Behavior
- **Default response shape is now `minified`** (was `pretty`). The common consumer is a token-sensitive LLM, so compact output is the sensible default; human-readable output is opt-in via `shape=pretty`. This supersedes the original byte-for-byte back-compat default — recorded as a dated amendment in ADR-0012.
- **Renamed shape token `sparse` → `defaults`.** It factors shared *default-valued* fields into a `defaults` block and omits them from rows; `sparse` wrongly implied omitting empty/null fields. Internally: `ShapeOpts::omit_defaults`, `factor_defaults()`.

### Docs
- README reorganized around operator questions (what it does → install → configure → connect a client → CLI reference), with copy-paste quick starts.
- Documented previously-undocumented surfaces: `--response-config`, OAuth 2.1 (`--oauth-issuer`/`--oauth-state-file`, incl. that `--api-token` gates the consent screen), and `--allowed-host`.
- Fixed the `--http-bind` default in docs (`127.0.0.1:8080`).
- Polished the clap `--help` doc-comments to match.

## Commits
- Change default response shape to minified
- docs: overhaul README for operators; update help text
- docs(adr): record minified-default change in ADR-0012
- Rename response shape token `sparse` to `defaults`
- Soften defaults-coverage wording; bump to 0.9.1

## Compatibility
Public DSL change vs what merged in #14: `shape=sparse` is no longer accepted (use `shape=defaults`), and the default is now minified. Both land before wide adoption.

## Verification
`cargo test` (85 passing) and `cargo build --release` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@